### PR TITLE
fix: :bug: fix missing dependencies for normal build

### DIFF
--- a/build/lib/plugin-manager.ts
+++ b/build/lib/plugin-manager.ts
@@ -28,6 +28,14 @@ export class PluginManager {
    * **Add new Pro plugins here to make them available in the application.**
    */
   private readonly pluginPaths: Record<string, PluginPathMapping> = {
+    'telemetry': {
+      openSourcePath: '../plugins/telemetry/telemetry',
+      proPath: '../plugins-pro/telemetry/telemetry',
+    },
+    'user-account': {
+      openSourcePath: '../plugins/user-account/user-account',
+      proPath: '../plugins-pro/user-account/user-account',
+    },
     'about-menu': {
       openSourcePath: '../plugins/about-menu/about-menu',
       proPath: '../plugins-pro/about-menu/about-menu',

--- a/build/webpack-manager.ts
+++ b/build/webpack-manager.ts
@@ -70,12 +70,16 @@ export class WebpackManager {
 
     // split entry points of main and webworkers
     const mainConfig = this.createMainConfig_(baseConfig, dirName, 'dist');
-    const authConfig = this.createAuthConfig_(baseConfig, dirName, 'dist', 'auth/');
     const webWorkerConfig = this.createWorkerConfig_(baseConfig, dirName, 'dist', '');
 
     webpackConfig.push(mainConfig);
-    webpackConfig.push(authConfig);
     webpackConfig.push(webWorkerConfig);
+
+    if (this.config.isPro) {
+      const authConfig = this.createAuthConfig_(baseConfig, dirName, 'dist', 'auth/');
+
+      webpackConfig.push(authConfig);
+    }
 
     // Modify the resolve configuration to handle web worker imports
     baseConfig.resolve!.fallback = {

--- a/src/plugins/telemetry/telemetry.ts
+++ b/src/plugins/telemetry/telemetry.ts
@@ -1,0 +1,7 @@
+export class Telemetry {
+  init() {
+    console.error(
+      'Telemetry plugin is a pro plugin. Your .env file is improperly configured or you do not have the pro files!',
+    );
+  }
+}


### PR DESCRIPTION
This pull request introduces support for two new Pro plugins—`telemetry` and `user-account`—and improves the build process to conditionally include the authentication bundle only for Pro builds. Additionally, a fallback implementation for the telemetry plugin is added to handle cases where the Pro version is not available.

**Pro plugin support and build process improvements:**

* Added `telemetry` and `user-account` to the `PluginManager` with both open source and Pro paths, enabling their use in the application.
* Updated the `WebpackManager` to include the authentication bundle (`authConfig`) only when building the Pro version, optimizing the build for open source users.

**Fallback implementation:**

* Added a fallback `Telemetry` class to the open source plugin, which logs an error if the Pro telemetry plugin is missing or misconfigured, providing clearer feedback for developers.