### PR TITLE
Guard against null data and stale references during catalog swap

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 All notable changes to this project will be documented in this file. Dates are displayed in UTC.
 
+#### [v12.2.10](https://github.com/thkruz/keeptrack.space/compare/v12.2.9...v12.2.10)
+
+>  
+
+- fix(draw-manager): :bug: guard mesh updates against null positionData during catalog swap [`539120e`](https://github.com/thkruz/keeptrack.space/commit/539120e57a5b54e314341c516acccda21045bd05)
+- fix(orbit-cruncher): :bug: validate id and seqNum in worker handlers to survive catalog swap [`c3f1803`](https://github.com/thkruz/keeptrack.space/commit/c3f1803440e28e0fed80bc77d77cb5cff94ade10)
+- fix(dots-manager): :bug: guard getPositionArray and getIdFromEci against null buffer [`b0eb51e`](https://github.com/thkruz/keeptrack.space/commit/b0eb51e502d0fdc52bf21a9d1df78d89d33ffb7e)
+- fix(sat-label-manager): :bug: guard label position updates against null buffer and stale satIds [`125e20d`](https://github.com/thkruz/keeptrack.space/commit/125e20dfa1d8ce79ce26b95e32622ff57a25e613)
+- docs(changelog): :memo: update changelog for version 12.2.9 with recent changes [`93160e6`](https://github.com/thkruz/keeptrack.space/commit/93160e6270a2171fd0c309d30b78742cdb380fd0)
+- fix(select-sat-manager): :bug: invalidate cached satellite references on catalog reload [`907579b`](https://github.com/thkruz/keeptrack.space/commit/907579bcb45c1f73d03edffe412a4b2cc5f0680b)
+- fix(sensor-manager): :bug: clear lastMultiSiteArray on catalog reload [`97e83fa`](https://github.com/thkruz/keeptrack.space/commit/97e83faa33c46ccec749bc628b29884ba34be406)
+- fix(position-cruncher): :bug: validate id against objCache in SAT_EDIT and NEW_MISSILE handlers [`b04ba19`](https://github.com/thkruz/keeptrack.space/commit/b04ba19994286347c033d8fe96eeecbbf3a03feb)
+- chore(plugins-pro): :wrench: update subproject commit reference [`a84869d`](https://github.com/thkruz/keeptrack.space/commit/a84869db9191a5d4f726c7f7fb03783f70e9d6c7)
+- chore(plugins-pro): :wrench: update subproject commit reference [`e006271`](https://github.com/thkruz/keeptrack.space/commit/e006271bd20a43466b8b6dbc8a537e3a0f690704)
+
 #### [v12.2.9](https://github.com/thkruz/keeptrack.space/compare/v12.2.8...v12.2.9)
 
 >  

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "keeptrack.space",
-  "version": "12.2.9",
+  "version": "12.2.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "keeptrack.space",
-      "version": "12.2.9",
+      "version": "12.2.10",
       "license": "AGPL-3.0",
       "dependencies": {
         "@e965/xlsx": "0.20.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "keeptrack.space",
-  "version": "12.2.9",
+  "version": "12.2.10",
   "type": "module",
   "description": "Complex astrodynamics tools designed for non-engineers to make learning about orbital mechanics and satellite operations more accessible.",
   "author": "Theodore Kruczek",

--- a/src/app/sensors/sensorManager.ts
+++ b/src/app/sensors/sensorManager.ts
@@ -162,6 +162,13 @@ export class SensorManager {
 
   constructor() {
     this.currentSensors = [];
+
+    // Multi-site look-angles results are keyed to satellite ids from the previous catalog.
+    // After a swap, the cached TearrData entries reference ids that may no longer exist or
+    // now point to different satellites. Drop the cache so exports and re-display rebuild.
+    EventBus.getInstance().on(EventBusEvent.catalogReloaded, () => {
+      this.lastMultiSiteArray = [];
+    });
   }
 
   static drawFov(sensor: DetailedSensor) {

--- a/src/app/threads/orbit-cruncher-thread-manager.ts
+++ b/src/app/threads/orbit-cruncher-thread-manager.ts
@@ -11,15 +11,19 @@ import { Degrees, Kilometers } from '@ootk/src/main';
 export class OrbitCruncherThreadManager extends WebWorkerThreadManager {
   readonly WEB_WORKER_CODE: string = 'js/orbitCruncher.js';
 
+  private currentSeqNum_ = 0;
+
   // ─── Typed Send Methods ─────────────────────────────────────────────
 
   sendInit(objData: string, numSegs: number, orbitFadeFactor?: number, numberOfOrbitsToDraw?: number): void {
+    this.currentSeqNum_++;
     this.postMessage({
       typ: OrbitCruncherMsgType.INIT,
       objData,
       numSegs,
       orbitFadeFactor,
       numberOfOrbitsToDraw,
+      seqNum: this.currentSeqNum_,
     });
   }
 
@@ -35,6 +39,7 @@ export class OrbitCruncherThreadManager extends WebWorkerThreadManager {
       isPolarViewEcf,
       tle1,
       tle2,
+      seqNum: this.currentSeqNum_,
     });
   }
 
@@ -52,6 +57,7 @@ export class OrbitCruncherThreadManager extends WebWorkerThreadManager {
       latList,
       lonList,
       altList,
+      seqNum: this.currentSeqNum_,
     });
   }
 
@@ -82,6 +88,11 @@ export class OrbitCruncherThreadManager extends WebWorkerThreadManager {
     const data = m.data as OrbitCruncherOutMsgPoints;
 
     if (!data || data.typ !== OrbitCruncherMsgType.RESPONSE_DATA) {
+      return;
+    }
+
+    // Discard stale responses from before the last catalog swap.
+    if (typeof data.seqNum === 'number' && data.seqNum < this.currentSeqNum_) {
       return;
     }
 

--- a/src/engine/rendering/dots-manager.ts
+++ b/src/engine/rendering/dots-manager.ts
@@ -463,7 +463,10 @@ export class DotsManager {
       return null;
     }
 
-    const effectiveMaxDots = maxDots ?? posData.length;
+    // positionData is xyz-packed (length = 3 * numSats). When the caller omits maxDots,
+    // the loop bound must be sat count, not buffer length, or we read past the end.
+    const satCount = Math.floor(posData.length / 3);
+    const effectiveMaxDots = typeof maxDots === 'number' ? Math.min(maxDots, satCount) : satCount;
     const possibleMatches: { id: number; distance: number }[] = [];
 
     // loop through all the satellites

--- a/src/engine/rendering/dots-manager.ts
+++ b/src/engine/rendering/dots-manager.ts
@@ -439,7 +439,15 @@ export class DotsManager {
   }
 
   getPositionArray(i: number): EciArr3 {
-    return [this.positionData[i * 3], this.positionData[i * 3 + 1], this.positionData[i * 3 + 2]] as EciArr3;
+    const posData = this.positionData;
+    const idx = i * 3;
+
+    // positionData is nulled during catalog swap; callers (line manager, scene offset, etc.) treat origin as a safe default
+    if (!posData || idx + 2 >= posData.length) {
+      return [0, 0, 0] as EciArr3;
+    }
+
+    return [posData[idx], posData[idx + 1], posData[idx + 2]] as EciArr3;
   }
 
   /**
@@ -448,14 +456,21 @@ export class DotsManager {
    * @param maxDots - The maximum number of satellites to search through.
    * @returns The ID of the closest satellite, or null if no satellite is found within 100km.
    */
-  getIdFromEci(eci: { x: number; y: number; z: number }, maxDots = this.positionData.length): number | null {
+  getIdFromEci(eci: { x: number; y: number; z: number }, maxDots?: number): number | null {
+    const posData = this.positionData;
+
+    if (!posData) {
+      return null;
+    }
+
+    const effectiveMaxDots = maxDots ?? posData.length;
     const possibleMatches: { id: number; distance: number }[] = [];
 
     // loop through all the satellites
-    for (let id = 0; id < maxDots; id++) {
-      const x = this.positionData[id * 3];
-      const y = this.positionData[id * 3 + 1];
-      const z = this.positionData[id * 3 + 2];
+    for (let id = 0; id < effectiveMaxDots; id++) {
+      const x = posData[id * 3];
+      const y = posData[id * 3 + 1];
+      const z = posData[id * 3 + 2];
 
       if (x > eci.x - 100 && x < eci.x + 100 && y > eci.y - 100 && y < eci.y + 100 && z > eci.z - 100 && z < eci.z + 100) {
         // if within 1km of the satellite, return it

--- a/src/engine/rendering/draw-manager/cone-mesh.ts
+++ b/src/engine/rendering/draw-manager/cone-mesh.ts
@@ -66,11 +66,18 @@ export class ConeMesh extends CustomMesh {
     this.targetObj = settings.targetObj ?? this.targetObj;
   }
 
-  private updatePosition_() {
+  private updatePosition_(): boolean {
     const positionData = ServiceLocator.getDotsManager()?.positionData;
-    const id = this.obj.id;
+    const idx = Number(this.obj.id) * 3;
 
-    this.pos = vec3.fromValues(positionData[Number(id) * 3], positionData[Number(id) * 3 + 1], positionData[Number(id) * 3 + 2]);
+    // positionData is nulled during catalog swap; resume on next cruncher message
+    if (!positionData || idx + 2 >= positionData.length) {
+      return false;
+    }
+
+    this.pos = vec3.fromValues(positionData[idx], positionData[idx + 1], positionData[idx + 2]);
+
+    return true;
   }
 
   /**
@@ -85,10 +92,14 @@ export class ConeMesh extends CustomMesh {
       return;
     }
 
-    this.updatePosition_();
+    if (!this.updatePosition_()) {
+      return;
+    }
 
     if (this.targetObj) {
-      this.updateSatToSat_();
+      if (!this.updateSatToSat_()) {
+        return;
+      }
     } else {
       this.updateEarthCenter_();
     }
@@ -149,15 +160,19 @@ export class ConeMesh extends CustomMesh {
     }
   }
 
-  private updateSatToSat_() {
+  private updateSatToSat_(): boolean {
     const worldShift = Scene.getInstance().worldShift;
     const positionData = ServiceLocator.getDotsManager()?.positionData;
-    const targetId = this.targetObj!.id;
+    const tIdx = Number(this.targetObj!.id) * 3;
+
+    if (!positionData || tIdx + 2 >= positionData.length) {
+      return false;
+    }
 
     // Target position from position buffer
-    const tx = positionData[Number(targetId) * 3];
-    const ty = positionData[Number(targetId) * 3 + 1];
-    const tz = positionData[Number(targetId) * 3 + 2];
+    const tx = positionData[tIdx];
+    const ty = positionData[tIdx + 1];
+    const tz = positionData[tIdx + 2];
 
     const px = this.pos[0];
     const py = this.pos[1];
@@ -170,7 +185,7 @@ export class ConeMesh extends CustomMesh {
     const dist = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
 
     if (dist < 1) {
-      return;
+      return false;
     }
 
     const dx = dirX / dist;
@@ -191,6 +206,8 @@ export class ConeMesh extends CustomMesh {
     const baseRadius = dist * Math.tan((this.fieldOfView * Math.PI) / 180);
 
     this.computeBaseCircle_(dx, dy, dz, baseCX, baseCY, baseCZ, baseRadius);
+
+    return true;
   }
 
   private computeBaseCircle_(dx: number, dy: number, dz: number, baseCX: number, baseCY: number, baseCZ: number, baseRadius: number) {

--- a/src/engine/rendering/draw-manager/frustum-mesh.ts
+++ b/src/engine/rendering/draw-manager/frustum-mesh.ts
@@ -84,11 +84,18 @@ export class FrustumMesh extends CustomMesh {
     this.elevationOffset = settings.elevationOffset || 0;
   }
 
-  private updatePosition_() {
+  private updatePosition_(): boolean {
     const positionData = ServiceLocator.getDotsManager()?.positionData;
-    const id = this.obj.id;
+    const idx = Number(this.obj.id) * 3;
 
-    this.pos = vec3.fromValues(positionData[Number(id) * 3], positionData[Number(id) * 3 + 1], positionData[Number(id) * 3 + 2]);
+    // positionData is nulled during catalog swap; resume on next cruncher message
+    if (!positionData || idx + 2 >= positionData.length) {
+      return false;
+    }
+
+    this.pos = vec3.fromValues(positionData[idx], positionData[idx + 1], positionData[idx + 2]);
+
+    return true;
   }
 
   update() {
@@ -96,10 +103,14 @@ export class FrustumMesh extends CustomMesh {
       return;
     }
 
-    this.updatePosition_();
+    if (!this.updatePosition_()) {
+      return;
+    }
 
     if (this.targetObj) {
-      this.updateSatToSat_();
+      if (!this.updateSatToSat_()) {
+        return;
+      }
     } else if (this.azimuthOffset !== 0 || this.elevationOffset !== 0) {
       this.updateFreeDirection_();
     } else {
@@ -142,14 +153,18 @@ export class FrustumMesh extends CustomMesh {
     this.computeFrustumCorners_(dx, dy, dz, ox, oy, oz, effectiveNear, effectiveFar);
   }
 
-  private updateSatToSat_() {
+  private updateSatToSat_(): boolean {
     const worldShift = Scene.getInstance().worldShift;
     const positionData = ServiceLocator.getDotsManager()?.positionData;
-    const targetId = this.targetObj!.id;
+    const tIdx = Number(this.targetObj!.id) * 3;
 
-    const tx = positionData[Number(targetId) * 3];
-    const ty = positionData[Number(targetId) * 3 + 1];
-    const tz = positionData[Number(targetId) * 3 + 2];
+    if (!positionData || tIdx + 2 >= positionData.length) {
+      return false;
+    }
+
+    const tx = positionData[tIdx];
+    const ty = positionData[tIdx + 1];
+    const tz = positionData[tIdx + 2];
 
     const px = this.pos[0];
     const py = this.pos[1];
@@ -162,7 +177,7 @@ export class FrustumMesh extends CustomMesh {
     const dist = Math.sqrt(dirX * dirX + dirY * dirY + dirZ * dirZ);
 
     if (dist < 1) {
-      return;
+      return false;
     }
 
     const dx = dirX / dist;
@@ -174,6 +189,8 @@ export class FrustumMesh extends CustomMesh {
     const oz = pz + worldShift[2];
 
     this.computeFrustumCorners_(dx, dy, dz, ox, oy, oz, this.nearDistance, this.farDistance);
+
+    return true;
   }
 
   private updateFreeDirection_() {
@@ -255,12 +272,12 @@ export class FrustumMesh extends CustomMesh {
     let hasVelocityRef = false;
 
     const velocityData = ServiceLocator.getDotsManager()?.velocityData;
+    const vIdx = Number(this.obj.id) * 3;
 
-    if (velocityData) {
-      const id = Number(this.obj.id);
-      const vx = velocityData[id * 3];
-      const vy = velocityData[id * 3 + 1];
-      const vz = velocityData[id * 3 + 2];
+    if (velocityData && vIdx + 2 < velocityData.length) {
+      const vx = velocityData[vIdx];
+      const vy = velocityData[vIdx + 1];
+      const vz = velocityData[vIdx + 2];
 
       // Use -velocity as reference so cross-product math yields up = velocity projection.
       // Verify the cross product has sufficient magnitude (fails when velocity is

--- a/src/engine/rendering/sat-label-manager.ts
+++ b/src/engine/rendering/sat-label-manager.ts
@@ -95,6 +95,12 @@ export class SatLabelManager {
     const positionData = dotsManager.positionData;
 
     if (!positionData) {
+      // draw() and updatePositions() key off instanceCount_; without zeroing it,
+      // the stale satPositionData_ from before the swap would keep rendering.
+      this.labeledSatIds_ = [];
+      this.labelGlyphCounts_ = [];
+      this.instanceCount_ = 0;
+
       return;
     }
 
@@ -154,6 +160,9 @@ export class SatLabelManager {
     const positionData = dotsManager.positionData;
 
     if (!positionData) {
+      // Stop draw() from rendering stale satPositionData_ until updateLabels rebuilds.
+      this.instanceCount_ = 0;
+
       return;
     }
 

--- a/src/engine/rendering/sat-label-manager.ts
+++ b/src/engine/rendering/sat-label-manager.ts
@@ -94,6 +94,10 @@ export class SatLabelManager {
     const dotsManager = ServiceLocator.getDotsManager();
     const positionData = dotsManager.positionData;
 
+    if (!positionData) {
+      return;
+    }
+
     this.labeledSatIds_ = [];
     this.labelGlyphCounts_ = [];
     let instanceIdx = 0;
@@ -102,6 +106,10 @@ export class SatLabelManager {
       const satId = visibleSatIds[s];
       const text = labelTexts[s];
       const posBase = satId * 3;
+
+      if (posBase + 2 >= positionData.length) {
+        continue;
+      }
 
       const px = positionData[posBase];
       const py = positionData[posBase + 1];
@@ -145,12 +153,22 @@ export class SatLabelManager {
     const dotsManager = ServiceLocator.getDotsManager();
     const positionData = dotsManager.positionData;
 
+    if (!positionData) {
+      return;
+    }
+
     let instanceIdx = 0;
 
     for (let s = 0; s < this.labeledSatIds_.length; s++) {
       const satId = this.labeledSatIds_[s];
       const glyphCount = this.labelGlyphCounts_[s];
       const posBase = satId * 3;
+
+      if (posBase + 2 >= positionData.length) {
+        // Stale labeledSatIds_ from before a catalog swap; skip until updateLabels() refreshes
+        instanceIdx += glyphCount;
+        continue;
+      }
       const px = positionData[posBase];
       const py = positionData[posBase + 1];
       const pz = positionData[posBase + 2];

--- a/src/plugins/select-sat-manager/select-sat-manager.ts
+++ b/src/plugins/select-sat-manager/select-sat-manager.ts
@@ -85,6 +85,17 @@ export class SelectSatManager extends KeepTrackPlugin {
         }
       }
     });
+
+    // Catalog swaps invalidate every cached satellite reference held here. The id-based
+    // selectedSat is reset by catalog-loader's selectSat(-1) call, but the JS object
+    // references aren't, so we clear them ourselves to avoid acting on a stale Satellite.
+    EventBus.getInstance().on(EventBusEvent.catalogReloaded, () => {
+      this.primarySatObj = this.noSatObj_;
+      this.primarySatCovMatrix = null;
+      this.secondarySatObj = null;
+      this.secondarySatCovMatrix = vec3.create();
+      this.lastSelectedSat_ = -1;
+    });
   }
 
   checkIfSelectSatVisible() {

--- a/src/plugins/select-sat-manager/select-sat-manager.ts
+++ b/src/plugins/select-sat-manager/select-sat-manager.ts
@@ -89,9 +89,12 @@ export class SelectSatManager extends KeepTrackPlugin {
     // Catalog swaps invalidate every cached satellite reference held here. The id-based
     // selectedSat is reset by catalog-loader's selectSat(-1) call, but the JS object
     // references aren't, so we clear them ourselves to avoid acting on a stale Satellite.
+    // secondarySat (the id) is also cleared here since catalog-loader doesn't touch it,
+    // and a stale id can collide with a new selection that happens to reuse the number.
     EventBus.getInstance().on(EventBusEvent.catalogReloaded, () => {
       this.primarySatObj = this.noSatObj_;
       this.primarySatCovMatrix = null;
+      this.secondarySat = -1;
       this.secondarySatObj = null;
       this.secondarySatCovMatrix = vec3.create();
       this.lastSelectedSat_ = -1;

--- a/src/webworker/orbit-cruncher-messages.ts
+++ b/src/webworker/orbit-cruncher-messages.ts
@@ -33,6 +33,8 @@ export interface OrbitCruncherInMsgInit {
   objData: string;
   numSegs: number;
   numberOfOrbitsToDraw?: number;
+  /** Catalog-swap sequence number. Worker rejects update messages older than the last INIT. */
+  seqNum?: number;
 }
 
 export interface OrbitCruncherInMsgSatelliteUpdate {
@@ -44,6 +46,7 @@ export interface OrbitCruncherInMsgSatelliteUpdate {
   tle2?: string;
   isEcfOutput: boolean;
   isPolarViewEcf?: boolean;
+  seqNum?: number;
 }
 
 export interface OrbitCruncherInMsgMissileUpdate {
@@ -56,6 +59,7 @@ export interface OrbitCruncherInMsgMissileUpdate {
   altList?: Kilometers[];
   isEcfOutput: boolean;
   isPolarViewEcf?: boolean;
+  seqNum?: number;
 }
 
 export interface OrbitCruncherInMsgChangeOrbitType {
@@ -81,6 +85,8 @@ export interface OrbitCruncherOutMsgPoints {
   typ: OrbitCruncherMsgType.RESPONSE_DATA;
   pointsOut: Float32Array;
   satId: number;
+  /** Echoes the seqNum the worker was on when it produced these points. Main thread drops stale responses. */
+  seqNum?: number;
 }
 
 // ─── Object Cache Types (used inside the worker) ───────────────────────────

--- a/src/webworker/orbitCruncher.ts
+++ b/src/webworker/orbitCruncher.ts
@@ -13,6 +13,10 @@ let numberOfSegments: number;
 let orbitType = OrbitDrawTypes.ORBIT;
 let orbitFadeFactor = 1.0;
 let numberOfOrbitsToDraw = 1;
+/** Tracks the last catalog-swap seqNum; per-id update messages older than this are discarded as stale. */
+let currentSeqNum = 0;
+
+const isStaleUpdate_ = (seqNum?: number): boolean => typeof seqNum === 'number' && seqNum < currentSeqNum;
 
 export const onMessage = (m: {
   data: OrbitCruncherInMsgs;
@@ -24,10 +28,16 @@ export const onMessage = (m: {
       handleMsgInit_(msg);
       break;
     case OrbitCruncherMsgType.SATELLITE_UPDATE:
+      if (isStaleUpdate_(msg.seqNum)) {
+        break;
+      }
       handleMsgSatelliteUpdate_(msg);
       updateOrbitData_(msg);
       break;
     case OrbitCruncherMsgType.MISSILE_UPDATE:
+      if (isStaleUpdate_(msg.seqNum)) {
+        break;
+      }
       handleMsgMissileUpdate_(msg);
       updateOrbitData_(msg);
       break;
@@ -54,11 +64,41 @@ const updateOrbitData_ = (data: OrbitCruncherInMsgSatelliteUpdate | OrbitCrunche
   const isPolarViewEcf = data.isPolarViewEcf || false;
   const pointsOut = new Float32Array((numberOfSegments + 1) * 4);
 
+  // Defensive bounds check: a catalog swap can shrink objCache, but in-flight
+  // update messages for old ids may still arrive. Reply with the zero buffer
+  // so the consumer (orbit-cruncher-thread-manager) sees a normal response
+  // and any waiting state (inProgress_, orbitCache) gets cleared.
+  if (id >= objCache.length || !objCache[id]) {
+    postMessage({
+      typ: OrbitCruncherMsgType.RESPONSE_DATA,
+      pointsOut,
+      satId: id,
+      seqNum: currentSeqNum,
+    }, { transfer: [pointsOut.buffer as ArrayBuffer] });
+
+    return;
+  }
+
   const len = numberOfSegments + 1;
   let i = 0;
   // Calculate Missile Orbits
 
   if ((objCache[id] as OrbitCruncherMissileObject).missile) {
+    const missile = objCache[id] as OrbitCruncherMissileObject;
+    const hasTrajectory = missile.latList && missile.lonList && missile.altList && missile.altList.length > 0;
+
+    if (!hasTrajectory) {
+      // pointsOut is already zero-initialized; nothing to draw until the missile trajectory is populated
+      postMessage({
+        typ: OrbitCruncherMsgType.RESPONSE_DATA,
+        pointsOut,
+        satId: id,
+        seqNum: currentSeqNum,
+      }, { transfer: [pointsOut.buffer as ArrayBuffer] });
+
+      return;
+    }
+
     // Compute GMST once for all missile segments (same time for all points)
     const missileJ =
       jday(nowDate.getUTCFullYear(), nowDate.getUTCMonth() + 1, nowDate.getUTCDate(), nowDate.getUTCHours(), nowDate.getUTCMinutes(), nowDate.getUTCSeconds()) +
@@ -66,18 +106,8 @@ const updateOrbitData_ = (data: OrbitCruncherInMsgSatelliteUpdate | OrbitCrunche
     const missileGmst = Sgp4.gstime(missileJ);
 
     while (i < len) {
-      const missile = objCache[id] as OrbitCruncherMissileObject;
-
-      if (missile.latList?.length === 0) {
-        pointsOut[i * 4] = 0;
-        pointsOut[i * 4 + 1] = 0;
-        pointsOut[i * 4 + 2] = 0;
-        pointsOut[i * 4 + 3] = 0;
-        i++;
-      } else {
-        drawMissileSegment_(missile, i, pointsOut, len, missileGmst);
-        i++;
-      }
+      drawMissileSegment_(missile, i, pointsOut, len, missileGmst);
+      i++;
     }
   } else if ((objCache[id] as OrbitCruncherOtherObject).ignore || !(objCache[id] as OrbitCruncherSatelliteObject).satrec) {
     // Invalid objects or OemSatellite with no TLEs
@@ -85,6 +115,7 @@ const updateOrbitData_ = (data: OrbitCruncherInMsgSatelliteUpdate | OrbitCrunche
       typ: OrbitCruncherMsgType.RESPONSE_DATA,
       pointsOut,
       satId: id,
+      seqNum: currentSeqNum,
     }, { transfer: [pointsOut.buffer as ArrayBuffer] });
 
     return;
@@ -128,6 +159,7 @@ const updateOrbitData_ = (data: OrbitCruncherInMsgSatelliteUpdate | OrbitCrunche
     typ: OrbitCruncherMsgType.RESPONSE_DATA,
     pointsOut,
     satId: id,
+    seqNum: currentSeqNum,
   }, { transfer: [pointsOut.buffer as ArrayBuffer] });
 };
 
@@ -209,6 +241,9 @@ const handleMsgInit_ = (data: OrbitCruncherInMsgInit) => {
   orbitFadeFactor = data.orbitFadeFactor ?? 1.0;
   numberOfOrbitsToDraw = data.numberOfOrbitsToDraw ?? 1;
   numberOfSegments = data.numSegs;
+  if (typeof data.seqNum === 'number') {
+    currentSeqNum = data.seqNum;
+  }
 
   const objData = JSON.parse(data.objData) as OrbitCruncherCachedObject[];
   const sLen = objData.length - 1;
@@ -229,10 +264,17 @@ const handleMsgInit_ = (data: OrbitCruncherInMsgInit) => {
     }
   }
 
+  // Drop residual entries from the previous (larger) catalog so SATELLITE_UPDATE
+  // for an id beyond the new range can't mutate a stale object.
+  objCache.length = objData.length;
+
   postMessage('ready');
 };
 
 const handleMsgSatelliteUpdate_ = (data: OrbitCruncherInMsgSatelliteUpdate) => {
+  if (data.id >= objCache.length || !objCache[data.id]) {
+    return;
+  }
   // If new orbit
   if (data.tle1 && data.tle2) {
     const satelliteCacheEntry = objCache[data.id] as OrbitCruncherSatelliteObject;
@@ -242,6 +284,9 @@ const handleMsgSatelliteUpdate_ = (data: OrbitCruncherInMsgSatelliteUpdate) => {
 };
 
 const handleMsgMissileUpdate_ = (data: OrbitCruncherInMsgMissileUpdate) => {
+  if (data.id >= objCache.length || !objCache[data.id]) {
+    return;
+  }
   if (data.latList && data.lonList && data.altList) {
     const missileCacheEntry = objCache[data.id] as OrbitCruncherMissileObject;
 

--- a/src/webworker/positionCruncher.ts
+++ b/src/webworker/positionCruncher.ts
@@ -316,6 +316,10 @@ export const onmessageProcessing = (m: PositionCruncherIncomingMsg) => {
         if (m.data.id === undefined) {
           break;
         }
+        // Discard edits for ids outside the current catalog (e.g. in-flight after a swap to a smaller catalog).
+        if (m.data.id >= objCache.length || !objCache[m.data.id]) {
+          break;
+        }
         // replace old TLEs
         const satrec = Sgp4.createSatrec(m.data.tle1, m.data.tle2);
 
@@ -358,7 +362,7 @@ export const onmessageProcessing = (m: PositionCruncherIncomingMsg) => {
       }
       break;
     case PosCruncherMsgType.NEW_MISSILE:
-      if (m.data.id !== undefined) {
+      if (m.data.id !== undefined && m.data.id < objCache.length) {
         objCache[m.data.id] = <PosCruncherCachedObject>(<unknown>m.data);
       }
       break;


### PR DESCRIPTION
This pull request focuses on improving the application's robustness during satellite catalog swaps. The main goal is to prevent errors and stale data usage by adding guards and cache invalidation throughout the codebase. These changes ensure that rendering, selection, and calculation logic handle catalog reloads gracefully, avoiding issues caused by null or outdated references.

**Key improvements include:**

### Robustness During Catalog Swaps

- Added checks and guards in mesh update methods (`ConeMesh`, `FrustumMesh`) to handle cases where `positionData` is null or insufficient, preventing errors during catalog swaps. These methods now return early if data is not available. [[1]](diffhunk://#diff-a7a27fd3439fc88065a1edfb20264a01d97503a9076d59de1780934bfb2cbe18L69-R80) [[2]](diffhunk://#diff-a7a27fd3439fc88065a1edfb20264a01d97503a9076d59de1780934bfb2cbe18L88-R102) [[3]](diffhunk://#diff-a7a27fd3439fc88065a1edfb20264a01d97503a9076d59de1780934bfb2cbe18L152-R175) [[4]](diffhunk://#diff-a7a27fd3439fc88065a1edfb20264a01d97503a9076d59de1780934bfb2cbe18L173-R188) [[5]](diffhunk://#diff-a7a27fd3439fc88065a1edfb20264a01d97503a9076d59de1780934bfb2cbe18R209-R210) [[6]](diffhunk://#diff-5c6e943292dd3a42db33d7a5e5c6e5071e222dc352e1c2ef3525c74707534debL87-R113) [[7]](diffhunk://#diff-5c6e943292dd3a42db33d7a5e5c6e5071e222dc352e1c2ef3525c74707534debL145-R167) [[8]](diffhunk://#diff-5c6e943292dd3a42db33d7a5e5c6e5071e222dc352e1c2ef3525c74707534debL165-R180) [[9]](diffhunk://#diff-5c6e943292dd3a42db33d7a5e5c6e5071e222dc352e1c2ef3525c74707534debR192-R193) [[10]](diffhunk://#diff-5c6e943292dd3a42db33d7a5e5c6e5071e222dc352e1c2ef3525c74707534debR275-R280)

- Updated `DotsManager` methods (`getPositionArray`, `getIdFromEci`) to safely handle null `positionData` and avoid out-of-bounds errors, returning default values when necessary. [[1]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6L442-R450) [[2]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6L451-R473)

- Improved `SatLabelManager` to skip label updates and rendering if `positionData` is unavailable or if satellite IDs are stale after a catalog reload. [[1]](diffhunk://#diff-a9c12f872f63865ec2c41a7ba0a4796238654e97f272ebbf04cf2e1e931ff8d8R97-R100) [[2]](diffhunk://#diff-a9c12f872f63865ec2c41a7ba0a4796238654e97f272ebbf04cf2e1e931ff8d8R110-R113) [[3]](diffhunk://#diff-a9c12f872f63865ec2c41a7ba0a4796238654e97f272ebbf04cf2e1e931ff8d8R156-R171)

### Cache and Reference Invalidation

- In `SensorManager`, added logic to clear the cached `lastMultiSiteArray` when the catalog is reloaded, ensuring no outdated look-angle results are used.

- In `SelectSatManager`, implemented a handler that clears all cached satellite object references on catalog reload, preventing actions on stale satellites.

### Orbit Cruncher Worker Sequence Numbering

- Introduced a sequence number (`seqNum`) system in `OrbitCruncherThreadManager` and related message interfaces to track catalog swaps. The main thread and worker now ignore messages/responses from previous catalogs, preventing race conditions and stale data processing. [[1]](diffhunk://#diff-4bfa4a7f61e6481c41e6cba85b1331565dd5006429c94c78cdde476191278cd4R14-R26) [[2]](diffhunk://#diff-4bfa4a7f61e6481c41e6cba85b1331565dd5006429c94c78cdde476191278cd4R42) [[3]](diffhunk://#diff-4bfa4a7f61e6481c41e6cba85b1331565dd5006429c94c78cdde476191278cd4R60) [[4]](diffhunk://#diff-4bfa4a7f61e6481c41e6cba85b1331565dd5006429c94c78cdde476191278cd4R94-R98) [[5]](diffhunk://#diff-0d83d879ff967bc75f1836b9fa3fea9d9bc3efb861da00667d4e5fb44e24a50aR36-R37) [[6]](diffhunk://#diff-0d83d879ff967bc75f1836b9fa3fea9d9bc3efb861da00667d4e5fb44e24a50aR49) [[7]](diffhunk://#diff-0d83d879ff967bc75f1836b9fa3fea9d9bc3efb861da00667d4e5fb44e24a50aR62) [[8]](diffhunk://#diff-0d83d879ff967bc75f1836b9fa3fea9d9bc3efb861da00667d4e5fb44e24a50aR88-R89)

### Maintenance and Documentation

- Updated the changelog for version 12.2.10, documenting these fixes and improvements.
- Bumped the project version in `package.json` and updated the plugins-pro subproject reference. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-269d6a3929be1f5cb462964314c836316739089246f9947976162a26b97882b3L1-R1)

These changes collectively make the application more stable and reliable, especially during and after satellite catalog reloads.