### PR TITLE
Update dependencies and add asset size limit checks

### DIFF
--- a/build/__tests__/deploy-asset-size.test.ts
+++ b/build/__tests__/deploy-asset-size.test.ts
@@ -1,0 +1,87 @@
+import { execFileSync } from 'node:child_process';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/*
+ * Cloudflare Pages rejects any single deployed file larger than 25 MiB.
+ *
+ * On 2026-07-08 all three Cloudflare Pages builds broke because
+ * public/tle/tle.json was converted to the verbose CelesTrak OMM JSON format,
+ * which ballooned it from ~18.9 MiB to ~28 MiB:
+ *
+ *   ✘ [ERROR] Error: Pages only supports files up to 25 MiB in size
+ *     tle/tle.json is 28 MiB in size
+ *
+ * Everything committed under public/ is copied verbatim into dist/ by
+ * build/build-manager.ts (copyTopLevelFiles + the resourceDirs list) and shipped
+ * to Cloudflare, so any tracked file that crosses the 25 MiB limit fails the
+ * deploy. This test guards that invariant so the mistake cannot recur silently.
+ *
+ * It scopes to git-TRACKED files on purpose: Cloudflare builds from a fresh
+ * clone, so gitignored local artifacts (e.g. the ~89 MiB
+ * public/data/catalog.notes.md) never reach the deploy and must not fail CI.
+ */
+const MIB = 1024 * 1024;
+
+/** Hard ceiling enforced by Cloudflare Pages. Exceeding it breaks the deploy. */
+const CLOUDFLARE_MAX_FILE_BYTES = 25 * MIB;
+
+/**
+ * Early-warning threshold. Files at or above this are still deployable but are
+ * close enough to the ceiling that the next content update could push them over,
+ * so we surface them loudly without failing the build.
+ */
+const DANGER_ZONE_BYTES = 22 * MIB;
+
+/** Repo-root-relative paths of every git-tracked file under public/. */
+const trackedPublicFiles = (): string[] => {
+  const stdout = execFileSync('git', ['ls-files', '-z', 'public'], {
+    encoding: 'utf8',
+    maxBuffer: 64 * MIB,
+  });
+
+  return stdout.split('\0').filter((path) => path.length > 0);
+};
+
+describe('Cloudflare Pages deploy asset size limits', () => {
+  const files = trackedPublicFiles();
+
+  it('finds tracked public/ assets to inspect', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it('keeps every committed public/ asset under the Cloudflare Pages 25 MiB per-file limit', () => {
+    const offenders: string[] = [];
+    const approaching: string[] = [];
+
+    for (const relPath of files) {
+      let size: number;
+
+      try {
+        size = statSync(join(process.cwd(), relPath)).size;
+      } catch {
+        continue; // Tracked-but-missing or symlink edge cases are not our concern here.
+      }
+
+      const sizeMib = (size / MIB).toFixed(1);
+
+      if (size >= CLOUDFLARE_MAX_FILE_BYTES) {
+        offenders.push(`${relPath} - ${sizeMib} MiB (limit 25 MiB)`);
+      } else if (size >= DANGER_ZONE_BYTES) {
+        approaching.push(`${relPath} - ${sizeMib} MiB`);
+      }
+    }
+
+    if (approaching.length > 0) {
+      console.warn(
+        `[deploy-asset-size] These committed public/ assets are approaching Cloudflare's 25 MiB per-file limit:\n  ${approaching.join('\n  ')}`,
+      );
+    }
+
+    expect(
+      offenders,
+      `The following committed public/ assets exceed Cloudflare Pages' 25 MiB per-file limit and will break the deploy:\n  ${offenders.join('\n  ')}\n\nShrink the file (e.g. keep the compact catalog format instead of verbose OMM JSON), split it, or serve it from an external host.`,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
This pull request introduces a new test to ensure that no single file in the `public/` directory exceeds Cloudflare Pages' 25 MiB per-file upload limit. This helps prevent deployment failures caused by accidentally committing large files, as happened previously with `public/tle/tle.json`. The test checks all git-tracked files under `public/`, warns about files nearing the limit, and fails the build if any file exceeds it.

**Cloudflare deploy asset size enforcement:**

* Added `build/__tests__/deploy-asset-size.test.ts` to automatically check that all git-tracked files in the `public/` directory are below the 25 MiB Cloudflare Pages per-file limit, warning for files above 22 MiB and failing for files above 25 MiB.