### PR TITLE
feat(plugins): :sparkles: warn with actionable message when pro plugin import fails

### DIFF
--- a/src/plugins/__tests__/plugin-manager.test.ts
+++ b/src/plugins/__tests__/plugin-manager.test.ts
@@ -121,6 +121,31 @@ describe('PluginManager.warnProImportFailed_', () => {
 
     expect(warnSpy.mock.calls[0][0]).toContain('Reason: plain string failure');
   });
+
+  it('serializes thrown objects as JSON instead of [object Object]', () => {
+    const descriptor = makeDescriptor({ ossImport: () => Promise.resolve({}) });
+
+    PM.warnProImportFailed_(descriptor, { code: 'MODULE_NOT_FOUND' });
+
+    const msg = warnSpy.mock.calls[0][0] as string;
+
+    expect(msg).toContain('Reason: {"code":"MODULE_NOT_FOUND"}');
+    expect(msg).not.toContain('[object Object]');
+  });
+
+  it('degrades to the type name for values JSON cannot serialize', () => {
+    const descriptor = makeDescriptor({ ossImport: () => Promise.resolve({}) });
+    const circular: Record<string, unknown> = {};
+
+    circular.self = circular;
+
+    PM.warnProImportFailed_(descriptor, circular);
+
+    const msg = warnSpy.mock.calls[0][0] as string;
+
+    expect(msg).toContain('Reason: object');
+    expect(msg).not.toContain('[object Object]');
+  });
 });
 
 describe('PluginManager.initPlugin_', () => {

--- a/src/plugins/__tests__/plugin-manager.test.ts
+++ b/src/plugins/__tests__/plugin-manager.test.ts
@@ -1,4 +1,5 @@
 /* eslint-disable max-classes-per-file */
+import { errorManagerInstance } from '@app/engine/utils/errorManager';
 import type { PluginDescriptor } from '@app/plugins/plugin-descriptor';
 import { PluginManager } from '@app/plugins/plugins';
 
@@ -17,6 +18,7 @@ import { PluginManager } from '@app/plugins/plugins';
 type PrivateStatics = {
   resolveModule_(descriptor: PluginDescriptor): Promise<{ mod: Record<string, unknown>; usedPro: boolean } | null>;
   initPlugin_(descriptor: PluginDescriptor, resolved: { mod: Record<string, unknown>; usedPro: boolean }): void;
+  warnProImportFailed_(descriptor: PluginDescriptor, error: unknown): void;
 };
 const PM = PluginManager as unknown as PrivateStatics;
 
@@ -58,6 +60,66 @@ describe('PluginManager.resolveModule_', () => {
     });
 
     await expect(PM.resolveModule_(descriptor)).rejects.toThrow('download-failed');
+  });
+});
+
+describe('PluginManager.warnProImportFailed_', () => {
+  /*
+   * The catch in resolveModule_ that calls this is unreachable here (__IS_PRO__
+   * is compile-time false in the OSS test build), so the warning logic is
+   * exercised directly. Guards issue #1206: a failed Pro import must produce an
+   * actionable message, not a silent fallback or a generic unavailable-feature
+   * message.
+   */
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warnSpy = vi.spyOn(errorManagerInstance, 'warn').mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  it('names the failed feature, the setup requirements, and the underlying reason', () => {
+    const descriptor = makeDescriptor({
+      configKey: 'Telemetry',
+      ossImport: () => Promise.resolve({}),
+    });
+
+    PM.warnProImportFailed_(descriptor, new Error('license missing'));
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    const msg = warnSpy.mock.calls[0][0] as string;
+
+    expect(msg).toContain('"Telemetry"');
+    expect(msg).toContain('IS_PRO=true');
+    expect(msg).toContain('src/plugins-pro');
+    expect(msg).toContain('Reason: license missing');
+  });
+
+  it('says it fell back to the standard version when an OSS variant exists', () => {
+    const descriptor = makeDescriptor({ ossImport: () => Promise.resolve({}) });
+
+    PM.warnProImportFailed_(descriptor, new Error('boom'));
+
+    expect(warnSpy.mock.calls[0][0]).toContain('Falling back to the standard version.');
+  });
+
+  it('says the feature is unavailable when there is no OSS variant', () => {
+    const descriptor = makeDescriptor({ proClassName: 'ProOnly' });
+
+    PM.warnProImportFailed_(descriptor, new Error('boom'));
+
+    expect(warnSpy.mock.calls[0][0]).toContain('The feature will be unavailable.');
+  });
+
+  it('stringifies non-Error rejection reasons', () => {
+    const descriptor = makeDescriptor({ ossImport: () => Promise.resolve({}) });
+
+    PM.warnProImportFailed_(descriptor, 'plain string failure');
+
+    expect(warnSpy.mock.calls[0][0]).toContain('Reason: plain string failure');
   });
 });
 

--- a/src/plugins/plugins.ts
+++ b/src/plugins/plugins.ts
@@ -40,7 +40,7 @@ export class PluginManager {
    * rather than silently degrading to the OSS variant.
    */
   private static warnProImportFailed_(descriptor: PluginDescriptor, error: unknown): void {
-    const reason = error instanceof Error ? error.message : String(error);
+    const reason = PluginManager.stringifyReason_(error);
     const fallback = descriptor.ossImport
       ? 'Falling back to the standard version.'
       : 'The feature will be unavailable.';
@@ -50,6 +50,25 @@ export class PluginManager {
       'Pro builds require the keeptrack-space-pro files in src/plugins-pro and IS_PRO=true in your .env ' +
       `(see https://keeptrack.space/). Reason: ${reason}`,
     );
+  }
+
+  /**
+   * Import rejections are usually Errors, but a thrown object must not degrade
+   * to '[object Object]' (typescript:S6551) — mirror errorManager's toError_.
+   */
+  private static stringifyReason_(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+    if (typeof error === 'string') {
+      return error;
+    }
+    try {
+      return JSON.stringify(error) ?? typeof error;
+    } catch {
+      // Circular structure — the type name is all that can be said about it.
+      return typeof error;
+    }
   }
 
   /**

--- a/src/plugins/plugins.ts
+++ b/src/plugins/plugins.ts
@@ -22,7 +22,10 @@ export class PluginManager {
     if (__IS_PRO__ && descriptor.proImport) {
       try {
         return { mod: await descriptor.proImport(), usedPro: true };
-      } catch { /* fall through to OSS */ }
+      } catch (error) {
+        PluginManager.warnProImportFailed_(descriptor, error);
+        // fall through to OSS
+      }
     }
 
     if (!descriptor.ossImport) {
@@ -30,6 +33,23 @@ export class PluginManager {
     }
 
     return { mod: await descriptor.ossImport(), usedPro: false };
+  }
+
+  /**
+   * Tell the user why a Pro feature is missing and what to do about it,
+   * rather than silently degrading to the OSS variant.
+   */
+  private static warnProImportFailed_(descriptor: PluginDescriptor, error: unknown): void {
+    const reason = error instanceof Error ? error.message : String(error);
+    const fallback = descriptor.ossImport
+      ? 'Falling back to the standard version.'
+      : 'The feature will be unavailable.';
+
+    errorManagerInstance.warn(
+      `Pro plugin "${descriptor.configKey}" failed to load. ${fallback} ` +
+      'Pro builds require the keeptrack-space-pro files in src/plugins-pro and IS_PRO=true in your .env ' +
+      `(see https://keeptrack.space/). Reason: ${reason}`,
+    );
   }
 
   /**


### PR DESCRIPTION
## Description

Closes #1206

When a Pro plugin import fails, the empty catch in `PluginManager.resolveModule_` swallows the reason and the build quietly falls back to OSS. The user never learns why the feature is missing.

This PR surfaces an actionable warning at the fall-through via the existing `errorManagerInstance.warn()`, so the user gets a toast and console warning that includes:

- which feature failed (`descriptor.configKey`)
- whether it fell back to the OSS variant or is unavailable
- the real setup requirements (keeptrack-space-pro files in `src/plugins-pro`, `IS_PRO=true` in `.env`)
- the underlying import failure reason

No placeholder URLs or invented env vars, per the triage notes on the issue.

## Testing

Added 4 unit tests in `plugin-manager.test.ts` covering the missing-license path requested in the issue: message names the feature, includes the setup requirements and reason, distinguishes fallback vs unavailable, and stringifies non-Error rejections. The warning logic lives in a small private static (`warnProImportFailed_`) because `__IS_PRO__` is compile-time false in the OSS test build, which makes the catch itself unreachable in vitest.

- `npx vitest run src/plugins/__tests__/plugin-manager.test.ts`: 15 passed
- `npm run typecheck`: clean
- `npx eslint` on both changed files: clean