### PR TITLE
Add workload counters and instrument render pipeline for diagnostics

### DIFF
--- a/src/app/rendering/orbit-manager.ts
+++ b/src/app/rendering/orbit-manager.ts
@@ -20,6 +20,7 @@ import { rotateEcefToEciZ } from '../../engine/math/orbit-anchor-math';
 import { KeyboardComponent } from '../../engine/plugins/components/keyboard/keyboard-component';
 import { ColorSchemeManager } from '../../engine/rendering/color-scheme-manager';
 import { LineManager } from '../../engine/rendering/line-manager';
+import { CounterStage, FrameProfiler } from '../../engine/utils/frame-profiler';
 import { HoverManager } from '../ui/hover-manager';
 
 export class OrbitManager {
@@ -772,6 +773,9 @@ export class OrbitManager {
         gl.bufferSubData(gl.ARRAY_BUFFER, 0, buf);
       }
     }
+
+    // Every orbit line drawn passes through here, so this is the one counter site
+    FrameProfiler.getInstance().addCounter(CounterStage.orbits, 1);
 
     if (variableLengthPath) {
       this.lineManagerInstance_.setAttribsAndDrawLineStrip(this.glBuffers_[id], variableLengthPath.length / 4);

--- a/src/engine/core/scene.ts
+++ b/src/engine/core/scene.ts
@@ -323,8 +323,14 @@ export class Scene {
 
     this.updateVisualsBasedOnPerformance_();
 
+    const profiler = FrameProfiler.getInstance();
+
     // Plugin-provided background renderer (e.g. flat map mode)
-    if (EventBus.getInstance().methods.renderCustomBackground()) {
+    profiler.beginGpu(GpuStage.customBackground);
+    const isCustomBackground = EventBus.getInstance().methods.renderCustomBackground();
+
+    profiler.endGpu(GpuStage.customBackground);
+    if (isCustomBackground) {
       return; // Plugin handled background rendering
     }
 
@@ -335,7 +341,6 @@ export class Scene {
     if (!settingsManager.isDrawLess) {
       if (settingsManager.isDrawSun && !isSecondaryPass) {
         const fb = settingsManager.isDisableGodrays ? null : this.frameBuffers.godrays;
-        const profiler = FrameProfiler.getInstance();
 
         // Draw the Sun to the Godrays Frame Buffer
         profiler.beginGpu(GpuStage.sun);
@@ -344,6 +349,8 @@ export class Scene {
 
         const sceneManager = ServiceLocator.getScene();
         const centerBodyEntity = sceneManager.getBodyById(settingsManager.centerBody);
+
+        profiler.beginGpu(GpuStage.occlusion);
 
         // Draw a black earth mesh on top of the sun in the godrays frame buffer
         // Skip in astronomy mode since Earth is hidden
@@ -373,6 +380,7 @@ export class Scene {
         ) {
           renderer.meshManager.drawOcclusion(camera.projectionMatrix, camera.matrixWorldInverse, renderer.postProcessingManager.programs.occlusion, this.frameBuffers.godrays);
         }
+        profiler.endGpu(GpuStage.occlusion);
 
         // Add the godrays effect to the godrays frame buffer and then apply it to the postprocessing buffer two
         renderer.postProcessingManager.curBuffer = null;
@@ -381,22 +389,34 @@ export class Scene {
         profiler.endGpu(GpuStage.godrays);
       }
 
+      profiler.beginGpu(GpuStage.skybox);
       this.skybox.render(renderer.postProcessingManager.curBuffer);
+      profiler.endGpu(GpuStage.skybox);
 
       if (!settingsManager.isDisablePlanets) {
         if (settingsManager.centerBody !== SolarBody.Earth && settingsManager.centerBody !== SolarBody.Sun) {
+          profiler.beginGpu(GpuStage.planets);
           this.getBodyById(settingsManager.centerBody)?.draw(this.sun.position, renderer.postProcessingManager.curBuffer);
+          profiler.endGpu(GpuStage.planets);
         }
 
       }
       if (settingsManager.centerBody === SolarBody.Earth || settingsManager.centerBody === SolarBody.Moon) {
         if (settingsManager.isDrawEarth !== false && camera.cameraType !== CameraType.ASTRONOMY && camera.cameraType !== CameraType.PLANETARIUM) {
+          // Timed separately from gpu:earth so the profile exposes that the
+          // Earth renders here AND in renderOpaque (a real double-draw cost).
+          profiler.beginGpu(GpuStage.earthBackground);
           this.earth.draw(renderer.postProcessingManager.curBuffer);
+          profiler.endGpu(GpuStage.earthBackground);
         }
+        profiler.beginGpu(GpuStage.planets);
         this.getBodyById(SolarBody.Moon)?.draw(this.sun.position, renderer.postProcessingManager.curBuffer);
+        profiler.endGpu(GpuStage.planets);
       }
 
+      profiler.beginGpu(GpuStage.scenery);
       EventBus.getInstance().emit(EventBusEvent.drawOptionalScenery);
+      profiler.endGpu(GpuStage.scenery);
     }
 
     renderer.postProcessingManager.curBuffer = null;
@@ -470,7 +490,7 @@ export class Scene {
     const profiler = FrameProfiler.getInstance();
 
     // Draw Earth (skip if plugin handles it; atmosphere-only in ground view modes; full draw otherwise)
-    profiler.beginGpu(GpuStage.earth);
+    // GPU timing lives inside Earth.draw so surface and atmosphere profile separately
     if (EventBus.getInstance().methods.shouldSkipEarthDraw()) {
       // Earth is drawn by plugin (e.g. 2D quad in renderBackground)
     } else if (settingsManager.isDrawEarth !== false) {
@@ -480,7 +500,6 @@ export class Scene {
         this.earth.draw(renderer.postProcessingManager.curBuffer);
       }
     }
-    profiler.endGpu(GpuStage.earth);
 
     // Draw Dots (dots + GPU picking are timed inside DotsManager.draw)
     dotsManagerInstance.draw(renderer.projectionCameraMatrix, renderer.postProcessingManager.curBuffer);

--- a/src/engine/engine.ts
+++ b/src/engine/engine.ts
@@ -183,11 +183,15 @@ export class Engine {
 
     this.sendCameraDataToWorker_();
 
+    // Post-draw plugin/UI work (DOM writes, orbit refreshes) — a common
+    // main-thread cost that is invisible to the GPU stages
+    profiler.beginCpu(CpuStage.endOfDraw);
     if (Engine.isFpsAboveLimit(dt, 5) && !settingsManager.lowPerf && !settingsManager.isDragging && !settingsManager.isDemoModeOn) {
       this.eventBus.emit(EventBusEvent.highPerformanceRender, dt);
     }
 
     this.eventBus.emit(EventBusEvent.endOfDraw, dt);
+    profiler.endCpu(CpuStage.endOfDraw);
 
     profiler.frameEnd();
   }

--- a/src/engine/input/input-manager.ts
+++ b/src/engine/input/input-manager.ts
@@ -11,6 +11,7 @@ import { t7e } from '@app/locales/keys';
 import { html } from '../utils/development/formatter';
 import { getEl, hideEl } from '../utils/get-el';
 import { errorManagerInstance } from '../utils/errorManager';
+import { CpuStage, FrameProfiler } from '../utils/frame-profiler';
 import { isThisNode } from '../utils/isThisNode';
 import { KeyboardInput } from './input-manager/keyboard-input';
 import { MouseInput } from './input-manager/mouse-input';
@@ -262,18 +263,26 @@ export class InputManager {
 
     // NOTE: gl.readPixels is a huge bottleneck but readPixelsAsync doesn't work properly on mobile.
     // readPixelsAsync swallows its own errors and flips isAsyncWorking; safe to fire-and-forget.
-    gl.bindFramebuffer(gl.FRAMEBUFFER, ServiceLocator.getScene().frameBuffers.gpuPicking);
-    if (!isThisNode() && this.isAsyncWorking && !settingsManager.isDisableAsyncReadPixels) {
-      this.readPixelsAsync(x, gl.drawingBufferHeight - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, dotsManagerInstance.pickReadPixelBuffer);
-    }
-    if (!this.isAsyncWorking) {
-      try {
-        gl.readPixels(x, gl.drawingBufferHeight - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, dotsManagerInstance.pickReadPixelBuffer);
-      } catch (e) {
-        this.disablePicking_(e);
+    // The sync path stalls the whole GL pipeline, so it is profiled per occurrence.
+    const profiler = FrameProfiler.getInstance();
 
-        return -1;
+    profiler.beginCpu(CpuStage.pickRead);
+    try {
+      gl.bindFramebuffer(gl.FRAMEBUFFER, ServiceLocator.getScene().frameBuffers.gpuPicking);
+      if (!isThisNode() && this.isAsyncWorking && !settingsManager.isDisableAsyncReadPixels) {
+        this.readPixelsAsync(x, gl.drawingBufferHeight - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, dotsManagerInstance.pickReadPixelBuffer);
       }
+      if (!this.isAsyncWorking) {
+        try {
+          gl.readPixels(x, gl.drawingBufferHeight - y, 1, 1, gl.RGBA, gl.UNSIGNED_BYTE, dotsManagerInstance.pickReadPixelBuffer);
+        } catch (e) {
+          this.disablePicking_(e);
+
+          return -1;
+        }
+      }
+    } finally {
+      profiler.endCpu(CpuStage.pickRead);
     }
 
     const buf = dotsManagerInstance.pickReadPixelBuffer;

--- a/src/engine/rendering/color-scheme-manager.ts
+++ b/src/engine/rendering/color-scheme-manager.ts
@@ -42,6 +42,7 @@ import { ServiceLocator } from '../core/service-locator';
 import { EventBus } from '../events/event-bus';
 import { EventBusEvent } from '../events/event-bus-events';
 import { BaseObject } from '../ootk/src/objects';
+import { CpuStage, FrameProfiler } from '../utils/frame-profiler';
 import { PersistenceManager, StorageKey } from '../utils/persistence-manager';
 import { CelestrakColorScheme } from './color-schemes/celestrak-color-scheme';
 import { ColorScheme, ColorSchemeColorMap, ColorSchemeParams } from './color-schemes/color-scheme';
@@ -180,6 +181,11 @@ export class ColorSchemeManager {
   }
 
   calculateColorBuffers(isForceRecolor = false): void {
+    // Main-thread coloring loop + GPU upload; a top jank source on weak
+    // machines, so it is profiled per occurrence (it does not run every frame)
+    const profiler = FrameProfiler.getInstance();
+
+    profiler.beginCpu(CpuStage.colorBuffers);
     try {
       /*
        * These two variables only need to be set once, but we want to make sure they aren't called before the satellites
@@ -271,6 +277,8 @@ export class ColorSchemeManager {
       this.lastColorScheme = this.currentColorScheme;
       this.isUseGroupColorScheme = false;
       errorManagerInstance.debug(e);
+    } finally {
+      profiler.endCpu(CpuStage.colorBuffers);
     }
   }
 

--- a/src/engine/rendering/dots-manager.ts
+++ b/src/engine/rendering/dots-manager.ts
@@ -17,7 +17,7 @@ import { EventBus } from '../events/event-bus';
 import { EventBusEvent } from '../events/event-bus-events';
 import { RADIUS_OF_EARTH } from '../utils/constants';
 import { glsl } from '../utils/development/formatter';
-import { FrameProfiler, GpuStage } from '../utils/frame-profiler';
+import { CounterStage, CpuStage, FrameProfiler, GpuStage } from '../utils/frame-profiler';
 import { ensureVelocityVec3 } from '../utils/space-object-invariants';
 import { BufferAttribute } from './buffer-attribute';
 import { DepthManager } from './depth-manager';
@@ -286,6 +286,9 @@ export class DotsManager {
     profiler.beginGpu(GpuStage.dots);
     gl.bindVertexArray(this.programs.dots.vao);
 
+    // The per-frame position upload is driver/CPU time that hits shared-memory
+    // (integrated) GPUs hardest, so it gets its own CPU stage
+    profiler.beginCpu(CpuStage.dotBuffers);
     gl.bindBuffer(gl.ARRAY_BUFFER, this.buffers.position);
     gl.enableVertexAttribArray(this.programs.dots.attribs.a_position.location);
     /*
@@ -305,6 +308,7 @@ export class DotsManager {
     if (this.shaderProvider_) {
       this.shaderProvider_.updateExtraBuffers(gl, this.extraBuffers_);
     }
+    profiler.endCpu(CpuStage.dotBuffers);
 
     /*
      * DEBUG:
@@ -319,6 +323,7 @@ export class DotsManager {
     const maxDrawable = this.positionData ? Math.floor(this.positionData.length / 3) : 0;
     const drawCount = Math.min(settingsManager.dotsOnScreen, maxDrawable);
 
+    profiler.addCounter(CounterStage.dots, drawCount);
     gl.drawArrays(gl.POINTS, 0, drawCount);
     gl.bindVertexArray(null);
     profiler.endGpu(GpuStage.dots);
@@ -888,6 +893,20 @@ export class DotsManager {
       return;
     }
 
+    // Main-thread time copying worker results (100k+ element typed arrays) —
+    // arrives between frames and competes with the render loop, so it is
+    // profiled per occurrence rather than per frame
+    const profiler = FrameProfiler.getInstance();
+
+    profiler.beginCpu(CpuStage.cruncherMsg);
+    try {
+      this.applyCruncherBuffers_(mData);
+    } finally {
+      profiler.endCpu(CpuStage.cruncherMsg);
+    }
+  }
+
+  private applyCruncherBuffers_(mData: SatCruncherMessageData) {
     if (typeof mData.gmst === 'number') {
       this.cruncherGmst = mData.gmst;
     }

--- a/src/engine/rendering/draw-manager/earth.ts
+++ b/src/engine/rendering/draw-manager/earth.ts
@@ -36,6 +36,7 @@ import { ShaderMaterial } from '@app/engine/rendering/shader-material';
 import { SphereGeometry } from '@app/engine/rendering/sphere-geometry';
 import { RADIUS_OF_EARTH } from '@app/engine/utils/constants';
 import { glsl } from '@app/engine/utils/development/formatter';
+import { FrameProfiler, GpuStage } from '@app/engine/utils/frame-profiler';
 import { CameraType } from '@app/engine/camera/camera-type';
 import { SelectSatManager } from '@app/plugins/select-sat-manager/select-sat-manager';
 import { EpochUTC, J2000, Kilometers, KilometersPerSecond, Seconds, Sun, TEME, Vector3D } from '@ootk/src/main';
@@ -147,18 +148,35 @@ export class Earth {
 
   /**
    * This is run once per frame to render the earth.
+   *
+   * GPU stages are timed here (not at the call site) so the surface and the
+   * atmosphere — very different fill-rate costs on weak GPUs — profile
+   * separately. When a caller wraps this whole draw in its own GPU stage
+   * (renderBackground's gpu:earth-background), these inner hooks are no-ops.
    */
   draw(tgtBuffer: WebGLFramebuffer | null) {
+    const profiler = FrameProfiler.getInstance();
+
+    profiler.beginGpu(GpuStage.earth);
     this.drawEarthSurface_(tgtBuffer);
+    profiler.endGpu(GpuStage.earth);
     if (settingsManager.isDrawAtmosphere === AtmosphereSettings.ON) {
+      profiler.beginGpu(GpuStage.atmosphere);
       this.drawEarthAtmosphere_(tgtBuffer);
+      profiler.endGpu(GpuStage.atmosphere);
     }
+    profiler.beginGpu(GpuStage.earth);
     this.drawBlackGpuPickingEarth_();
+    profiler.endGpu(GpuStage.earth);
   }
 
   drawAtmosphereOnly(tgtBuffer: WebGLFramebuffer | null) {
     if (settingsManager.isDrawAtmosphere === AtmosphereSettings.ON) {
+      const profiler = FrameProfiler.getInstance();
+
+      profiler.beginGpu(GpuStage.atmosphere);
       this.drawEarthAtmosphere_(tgtBuffer);
+      profiler.endGpu(GpuStage.atmosphere);
     }
   }
 

--- a/src/engine/rendering/line-manager.ts
+++ b/src/engine/rendering/line-manager.ts
@@ -19,6 +19,7 @@ import { EventBusEvent } from '../events/event-bus-events';
 import { getTemeToJ2000Matrix, ReferenceFrame } from '../math/reference-frames';
 import { EARTH_OBLIQUITY_RADIANS, RADIUS_OF_EARTH } from '../utils/constants';
 import { glsl } from '../utils/development/formatter';
+import { CounterStage, FrameProfiler } from '../utils/frame-profiler';
 import { DepthManager } from './depth-manager';
 import { Line, LineColor, LineColors } from './line-manager/line';
 import { ObjToObjLine } from './line-manager/obj-to-obj-line';
@@ -502,6 +503,8 @@ export class LineManager {
     if (this.lines.length === 0) {
       return;
     }
+
+    FrameProfiler.getInstance().addCounter(CounterStage.lines, this.lines.length);
 
     const modelViewMatrix = mat4.create();
     const gl = ServiceLocator.getRenderer().gl;

--- a/src/engine/rendering/sat-label-manager.ts
+++ b/src/engine/rendering/sat-label-manager.ts
@@ -4,6 +4,7 @@ import { Scene } from '../core/scene';
 import { ServiceLocator } from '../core/service-locator';
 import { RADIUS_OF_EARTH } from '../utils/constants';
 import { glsl } from '../utils/development/formatter';
+import { CounterStage, FrameProfiler } from '../utils/frame-profiler';
 import { BufferAttribute } from './buffer-attribute';
 import { DepthManager } from './depth-manager';
 import { WebGlProgramHelper } from './webgl-program';
@@ -200,6 +201,8 @@ export class SatLabelManager {
     if (!this.isReady_ || this.instanceCount_ === 0) {
       return;
     }
+
+    FrameProfiler.getInstance().addCounter(CounterStage.labelGlyphs, this.instanceCount_);
 
     const gl = this.gl_;
 

--- a/src/engine/rendering/viewport-manager.ts
+++ b/src/engine/rendering/viewport-manager.ts
@@ -8,6 +8,7 @@ import { Scene } from '../core/scene';
 import { ServiceLocator } from '../core/service-locator';
 import { EventBus } from '../events/event-bus';
 import { EventBusEvent } from '../events/event-bus-events';
+import { CounterStage, FrameProfiler } from '../utils/frame-profiler';
 import { LayoutInsets, Viewport, ViewportLayout } from './viewport';
 import type { WebGLRenderer } from './webgl-renderer';
 
@@ -256,8 +257,10 @@ export class ViewportManager {
    */
   renderAll(renderer: WebGLRenderer, scene: Scene, mainCamera: Camera): void {
     const mainViewport = this.ensureMainViewport(mainCamera);
+    const profiler = FrameProfiler.getInstance();
 
     if (!this.isMultiViewActive()) {
+      profiler.addCounter(CounterStage.viewportPasses, 1);
       mainViewport.camera.viewport = null;
       mainViewport.camera.draw(renderer.sensorPos);
       renderer.render(scene, mainViewport.camera);
@@ -282,6 +285,7 @@ export class ViewportManager {
 
       const camera = viewport.camera;
 
+      profiler.addCounter(CounterStage.viewportPasses, 1);
       this.activePass_ = viewport;
       ServiceLocator.setActiveRenderCamera(camera);
       try {

--- a/src/engine/utils/__tests__/frame-profiler.test.ts
+++ b/src/engine/utils/__tests__/frame-profiler.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { CpuStage, FrameProfiler } from '@app/engine/utils/frame-profiler';
+import { CounterStage, CpuStage, FrameProfiler } from '@app/engine/utils/frame-profiler';
 
 /**
  * The profiler is a singleton; each test resets it to a clean, disabled state.
@@ -118,5 +118,45 @@ describe('FrameProfiler', () => {
 
     expect(snap.frames).toBe(0);
     expect(snap.cpu).toHaveLength(0);
+  });
+
+  it('accumulates counters within a frame and flushes one sample per frame', () => {
+    profiler.setEnabled(true);
+    // Two render passes in the same frame add up (multi-viewport)
+    profiler.frameStart(16);
+    profiler.addCounter(CounterStage.dots, 20000);
+    profiler.addCounter(CounterStage.dots, 5000);
+    profiler.frameEnd();
+    // A lighter second frame
+    profiler.frameStart(16);
+    profiler.addCounter(CounterStage.dots, 10000);
+    profiler.frameEnd();
+
+    const dots = profiler.getSnapshot().counters.find((s) => s.id === CounterStage.dots);
+
+    expect(dots).toBeDefined();
+    expect(dots!.samples).toBe(2);
+    expect(dots!.max).toBe(25000);
+    expect(dots!.avg).toBeCloseTo(17500, 3);
+  });
+
+  it('records nothing for counters while disabled', () => {
+    profiler.frameStart(16);
+    profiler.addCounter(CounterStage.orbits, 100);
+    profiler.frameEnd();
+
+    expect(profiler.getSnapshot().counters).toHaveLength(0);
+  });
+
+  it('tallies frames slower than the 30fps budget as long frames', () => {
+    profiler.setEnabled(true);
+    runFrame(16, CpuStage.camera, 1);
+    runFrame(50, CpuStage.camera, 1);
+    runFrame(40, CpuStage.camera, 1);
+
+    const snap = profiler.getSnapshot();
+
+    expect(snap.frames).toBe(3);
+    expect(snap.longFrames).toBe(2);
   });
 });

--- a/src/engine/utils/frame-profiler.ts
+++ b/src/engine/utils/frame-profiler.ts
@@ -30,6 +30,8 @@ const RING_CAPACITY = 240;
 const MAX_PENDING_QUERIES = 64;
 /** Free-list cap for recycled query objects. */
 const QUERY_POOL_CAP = 32;
+/** Frames slower than this (30fps budget) count toward the long-frame tally. */
+const LONG_FRAME_MS = 33.4;
 
 /** CPU stage identifiers. Kept stable - the UI humanizes them for display. */
 export const CpuStage = {
@@ -40,13 +42,25 @@ export const CpuStage = {
   sceneUpdate: 'cpu:scene-update',
   orbitsAbove: 'cpu:orbits-above',
   drawSubmit: 'cpu:draw-submit',
+  endOfDraw: 'cpu:end-of-draw',
+  pickRead: 'cpu:pick-readback',
+  colorBuffers: 'cpu:color-buffers',
+  dotBuffers: 'cpu:dot-buffer-upload',
+  cruncherMsg: 'cpu:cruncher-message',
 } as const;
 
 /** GPU stage identifiers (non-overlapping leaves within one frame). */
 export const GpuStage = {
   sun: 'gpu:sun',
+  occlusion: 'gpu:occlusion',
   godrays: 'gpu:godrays',
+  skybox: 'gpu:skybox',
+  planets: 'gpu:planets',
+  earthBackground: 'gpu:earth-background',
+  scenery: 'gpu:scenery',
+  customBackground: 'gpu:custom-background',
   earth: 'gpu:earth',
+  atmosphere: 'gpu:atmosphere',
   dots: 'gpu:dots',
   picking: 'gpu:picking',
   labels: 'gpu:labels',
@@ -58,11 +72,24 @@ export const GpuStage = {
 } as const;
 
 /**
+ * Per-frame workload counters (how MUCH was drawn, to correlate with how LONG
+ * stages took). Values accumulate across render passes within one frame.
+ */
+export const CounterStage = {
+  dots: 'count:dots-drawn',
+  orbits: 'count:orbits-drawn',
+  labelGlyphs: 'count:label-glyphs',
+  lines: 'count:lines-drawn',
+  viewportPasses: 'count:viewport-passes',
+} as const;
+
+/**
  * Top-level CPU stages whose averages sum to a meaningful main-thread total.
  * Excludes the renderer sub-stages (camera/scene/etc.) which are nested inside
- * {@link CpuStage.rendererUpdate} and would double-count.
+ * {@link CpuStage.rendererUpdate} and would double-count, plus the off-loop
+ * stages (cruncher messages) that don't run every frame.
  */
-const TOP_LEVEL_CPU_STAGES = new Set<string>([CpuStage.updateEvent, CpuStage.rendererUpdate, CpuStage.drawSubmit]);
+const TOP_LEVEL_CPU_STAGES = new Set<string>([CpuStage.updateEvent, CpuStage.rendererUpdate, CpuStage.drawSubmit, CpuStage.endOfDraw]);
 
 export interface StageStat {
   id: string;
@@ -82,10 +109,14 @@ export interface ProfilerSnapshot {
   frameTimeMs: { avg: number; p50: number; p95: number; p99: number; max: number };
   cpu: StageStat[];
   gpu: StageStat[];
+  /** Per-frame workload counts (dots/orbits/labels drawn, render passes). */
+  counters: StageStat[];
   /** Sum of GPU stage averages. Valid because GPU stages never overlap. */
   gpuTotalAvgMs: number;
   /** Sum of the top-level CPU stage averages (no nested double-counting). */
   cpuTopAvgMs: number;
+  /** Cumulative frames slower than the 30fps budget since profiling started. */
+  longFrames: number;
   /** Count of GPU_DISJOINT events - high values mean GPU timings are unreliable. */
   disjointEvents: number;
 }
@@ -112,6 +143,22 @@ class Ring {
     if (this.count_ < this.buf_.length) {
       this.count_++;
     }
+  }
+
+  /**
+   * Adds to the most recent sample instead of pushing a new one. Used to merge
+   * results from the same stage rendered multiple times in one frame (e.g.
+   * multi-viewport passes) so a sample always means "ms per frame".
+   */
+  addToLast(value: number): void {
+    if (this.count_ === 0) {
+      this.push(value);
+
+      return;
+    }
+    const i = (this.idx_ - 1 + this.buf_.length) % this.buf_.length;
+
+    this.buf_[i] += value;
   }
 
   clear(): void {
@@ -172,6 +219,8 @@ function percentile(sortedAsc: number[], p: number): number {
 interface PendingQuery {
   stage: string;
   query: WebGLQuery;
+  /** Frame the query was issued in, so same-stage passes merge per frame. */
+  frameId: number;
 }
 
 /**
@@ -187,6 +236,8 @@ class GpuTimer {
   private readonly pending_: PendingQuery[] = [];
   private readonly free_: WebGLQuery[] = [];
   disjointEvents = 0;
+  /** Set once per frame by the profiler; stamps queries issued that frame. */
+  frameId = 0;
 
   get supported(): boolean {
     return this.supported_;
@@ -226,7 +277,7 @@ class GpuTimer {
     }
     this.gl_.beginQuery(this.ext_.TIME_ELAPSED_EXT, query);
     this.activeStage_ = stage;
-    this.pending_.push({ stage, query });
+    this.pending_.push({ stage, query, frameId: this.frameId });
   }
 
   end(stage: string): void {
@@ -237,8 +288,8 @@ class GpuTimer {
     this.activeStage_ = null;
   }
 
-  /** Resolves completed queries, feeding each stage's elapsed ms to `sink`. */
-  poll(sink: (stage: string, ms: number) => void): void {
+  /** Resolves completed queries, feeding each stage's elapsed ms + frame to `sink`. */
+  poll(sink: (stage: string, ms: number, frameId: number) => void): void {
     if (!this.supported_ || !this.gl_ || !this.ext_) {
       return;
     }
@@ -274,7 +325,7 @@ class GpuTimer {
       }
       const ns = gl.getQueryParameter(head.query, gl.QUERY_RESULT) as number;
 
-      sink(head.stage, ns / 1e6);
+      sink(head.stage, ns / 1e6, head.frameId);
       this.recycle_(head.query);
       this.pending_.shift();
     }
@@ -334,9 +385,14 @@ export class FrameProfiler {
   private readonly frameTime_ = new Ring(RING_CAPACITY);
   private readonly cpuRings_ = new Map<string, Ring>();
   private readonly gpuRings_ = new Map<string, Ring>();
+  private readonly counterRings_ = new Map<string, Ring>();
   private readonly cpuStart_ = new Map<string, number>();
   private readonly cpuFrameSum_ = new Map<string, number>();
+  private readonly counterFrameSum_ = new Map<string, number>();
+  /** Last frame each GPU stage pushed a sample for, to merge same-frame passes. */
+  private readonly gpuLastFrame_ = new Map<string, number>();
   private frames_ = 0;
+  private longFrames_ = 0;
 
   get enabled(): boolean {
     return this.enabled_;
@@ -363,9 +419,13 @@ export class FrameProfiler {
     this.frameTime_.clear();
     this.cpuRings_.clear();
     this.gpuRings_.clear();
+    this.counterRings_.clear();
     this.cpuStart_.clear();
     this.cpuFrameSum_.clear();
+    this.counterFrameSum_.clear();
+    this.gpuLastFrame_.clear();
     this.frames_ = 0;
+    this.longFrames_ = 0;
     this.gpu_.disjointEvents = 0;
   }
 
@@ -376,8 +436,12 @@ export class FrameProfiler {
     }
     if (dt > 0) {
       this.frameTime_.push(dt);
+      if (dt > LONG_FRAME_MS) {
+        this.longFrames_++;
+      }
     }
     this.frames_++;
+    this.gpu_.frameId = this.frames_;
   }
 
   /** Called once at the end of the frame: flush CPU sums, resolve GPU queries. */
@@ -389,8 +453,22 @@ export class FrameProfiler {
       this.ringFor_(this.cpuRings_, stage).push(sum);
     }
     this.cpuFrameSum_.clear();
-    this.gpu_.poll((stage, ms) => {
-      this.ringFor_(this.gpuRings_, stage).push(ms);
+    for (const [stage, sum] of this.counterFrameSum_) {
+      this.ringFor_(this.counterRings_, stage).push(sum);
+    }
+    this.counterFrameSum_.clear();
+    this.gpu_.poll((stage, ms, frameId) => {
+      const ring = this.ringFor_(this.gpuRings_, stage);
+
+      // Same stage rendered again in the same frame (second earth draw,
+      // multi-viewport pass): merge into that frame's sample so one sample
+      // always means "ms per frame", not "ms per pass".
+      if (this.gpuLastFrame_.get(stage) === frameId) {
+        ring.addToLast(ms);
+      } else {
+        ring.push(ms);
+        this.gpuLastFrame_.set(stage, frameId);
+      }
     });
   }
 
@@ -429,12 +507,25 @@ export class FrameProfiler {
     this.gpu_.end(stage);
   }
 
+  /**
+   * Accumulates a per-frame workload count (dots drawn, orbits drawn, render
+   * passes...). Multiple calls within one frame add up; the total is flushed
+   * as one sample at {@link frameEnd}.
+   */
+  addCounter(stage: string, value: number): void {
+    if (!this.enabled_ || value <= 0) {
+      return;
+    }
+    this.counterFrameSum_.set(stage, (this.counterFrameSum_.get(stage) ?? 0) + value);
+  }
+
   getSnapshot(): ProfilerSnapshot {
     const frameSorted = this.frameTime_.sorted();
     const frameAvg = this.frameTime_.avg();
     const frameP99 = percentile(frameSorted, 99);
     const cpu = this.collectStats_(this.cpuRings_);
     const gpu = this.collectStats_(this.gpuRings_);
+    const counters = this.collectStats_(this.counterRings_);
     const gpuTotalAvgMs = gpu.reduce((sum, s) => sum + s.avg, 0);
     const cpuTopAvgMs = cpu
       .filter((s) => TOP_LEVEL_CPU_STAGES.has(s.id))
@@ -457,8 +548,10 @@ export class FrameProfiler {
       },
       cpu,
       gpu,
+      counters,
       gpuTotalAvgMs,
       cpuTopAvgMs,
+      longFrames: this.longFrames_,
       disjointEvents: this.gpu_.disjointEvents,
     };
   }


### PR DESCRIPTION
This pull request adds detailed performance profiling throughout the rendering and input pipeline, enabling fine-grained measurement of both CPU and GPU costs for key rendering and data processing stages. The changes introduce new profiling hooks and counters, allowing developers to identify bottlenecks and optimize expensive operations, especially on weaker hardware.

**Profiling Enhancements:**

* Added `FrameProfiler` hooks to major rendering stages (e.g., custom backgrounds, sun, occlusion, skybox, planets, Earth, scenery) in `Scene`, with separate GPU timings for surface and atmosphere rendering in `Earth.draw`. This enables precise measurement of GPU time spent on each visual component. [[1]](diffhunk://#diff-47d6e1b054fd73e225248b966108015099e5836b1a0c43c8a167a9fdcf159fbeR326-R333) [[2]](diffhunk://#diff-47d6e1b054fd73e225248b966108015099e5836b1a0c43c8a167a9fdcf159fbeR353-R354) [[3]](diffhunk://#diff-47d6e1b054fd73e225248b966108015099e5836b1a0c43c8a167a9fdcf159fbeR383) [[4]](diffhunk://#diff-47d6e1b054fd73e225248b966108015099e5836b1a0c43c8a167a9fdcf159fbeR392-R419) [[5]](diffhunk://#diff-caa7d799baccd750024016067b3b2c97010d35612be1226c1bf7d55b25777bc9R151-R179)
* Added CPU profiling for main-thread bottlenecks, including color buffer calculation (`ColorSchemeManager.calculateColorBuffers`), dot buffer uploads and worker message handling (`DotsManager`), synchronous GPU picking reads (`InputManager`), and post-draw plugin/UI work (`Engine`). [[1]](diffhunk://#diff-aa32c9d7222fb3f0128c0bd939f268d92c9d4bfd5c5926f50b687c0d38adf33aR184-R188) [[2]](diffhunk://#diff-aa32c9d7222fb3f0128c0bd939f268d92c9d4bfd5c5926f50b687c0d38adf33aR280-R281) [[3]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6R289-R291) [[4]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6R311) [[5]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6R896-R909) [[6]](diffhunk://#diff-d2969ce25b54e6faa115d3147b121d92b4af065c87beb55be27070da8feadae4R266-R270) [[7]](diffhunk://#diff-d2969ce25b54e6faa115d3147b121d92b4af065c87beb55be27070da8feadae4R284-R286) [[8]](diffhunk://#diff-4cbf43f37f351f7f4cd5559150b9abeddc2ecfec94280eb6080e03a575e75f6dR186-R194)

**Profiling Counters:**

* Introduced per-frame counters for key rendering passes: number of orbits drawn (`OrbitManager`), lines (`LineManager`), dots (`DotsManager`), label glyphs (`SatLabelManager`), and viewport passes (`ViewportManager`). These help track rendering workload and scene complexity. [[1]](diffhunk://#diff-c956453d01fc9d49d09c0a3cb16a0226d0f636f3dc204c87162595b242bb582cR777-R779) [[2]](diffhunk://#diff-12eb5e8bb1d45a00cbdd2009e588820d039a4a47bb9f8af01218c4c5f50e0230R507-R508) [[3]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6R326) [[4]](diffhunk://#diff-a9c12f872f63865ec2c41a7ba0a4796238654e97f272ebbf04cf2e1e931ff8d8R205-R206) [[5]](diffhunk://#diff-234cf7b8a9e98bef44df13b78ef74bc39d3b127cab01eea3fc3707650d926fa4R260-R263)

**Codebase Updates:**

* Updated imports to include new profiling types (`CpuStage`, `GpuStage`, `CounterStage`, `FrameProfiler`) in all affected files. [[1]](diffhunk://#diff-c956453d01fc9d49d09c0a3cb16a0226d0f636f3dc204c87162595b242bb582cR23) [[2]](diffhunk://#diff-d2969ce25b54e6faa115d3147b121d92b4af065c87beb55be27070da8feadae4R14) [[3]](diffhunk://#diff-aa32c9d7222fb3f0128c0bd939f268d92c9d4bfd5c5926f50b687c0d38adf33aR45) [[4]](diffhunk://#diff-2042c93ee6e6ff65e9819311fb44b810e658f5bccf2de3b21693d0d0cfff8af6L20-R20) [[5]](diffhunk://#diff-caa7d799baccd750024016067b3b2c97010d35612be1226c1bf7d55b25777bc9R39) [[6]](diffhunk://#diff-12eb5e8bb1d45a00cbdd2009e588820d039a4a47bb9f8af01218c4c5f50e0230R22) [[7]](diffhunk://#diff-a9c12f872f63865ec2c41a7ba0a4796238654e97f272ebbf04cf2e1e931ff8d8R7) [[8]](diffhunk://#diff-234cf7b8a9e98bef44df13b78ef74bc39d3b127cab01eea3fc3707650d926fa4R11)

These enhancements provide much deeper visibility into the rendering pipeline's performance characteristics, making it easier to diagnose and address slowdowns or jank, especially on lower-end devices.