### PR TITLE
Update Supabase URL and subproject commit reference

### DIFF
--- a/configs/offline/profile.env
+++ b/configs/offline/profile.env
@@ -1,5 +1,5 @@
 MODE=development
 IS_PRO=true
 EDITION=offline
-PUBLIC_SUPABASE_URL=https://ucukugprniwigzqnqpuz.supabase.co
+PUBLIC_SUPABASE_URL=https://auth.keeptrack.space
 PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVjdWt1Z3Bybml3aWd6cW5xcHV6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNjIyODQsImV4cCI6MjA3MDgzODI4NH0.1Cd5tTJ_XAKFf30dGjk7W5vTTat9tOemF9iQ57c4Pu4

--- a/configs/pro/profile.env
+++ b/configs/pro/profile.env
@@ -7,7 +7,10 @@ EDITION=pro
 # default to a wasm build. Options: sgp4 (pure TypeScript), sgp4-wasm (classic),
 # sgp4-xp-wasm (SGP4-XP). Users can still switch at runtime.
 PROPAGATOR_BACKEND=sgp4-xp-wasm
-# Public Supabase URL
-PUBLIC_SUPABASE_URL=https://ucukugprniwigzqnqpuz.supabase.co
+# Public Supabase URL (custom domain -> proxies to ucukugprniwigzqnqpuz.supabase.co).
+# Using the keeptrack.space-owned host keeps auth on the same registrable domain as
+# the app, so corporate secure-web-gateways (e.g. Menlo) that allow keeptrack.space
+# but block the random *.supabase.co host don't break login (#1406).
+PUBLIC_SUPABASE_URL=https://auth.keeptrack.space
 # Public Supabase Anon Key
 PUBLIC_SUPABASE_ANON_KEY=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6InVjdWt1Z3Bybml3aWd6cW5xcHV6Iiwicm9sZSI6ImFub24iLCJpYXQiOjE3NTUyNjIyODQsImV4cCI6MjA3MDgzODI4NH0.1Cd5tTJ_XAKFf30dGjk7W5vTTat9tOemF9iQ57c4Pu4


### PR DESCRIPTION
This pull request updates the Supabase public URL configuration for both the offline and pro editions to use a custom domain, improving authentication reliability for users behind corporate secure web gateways. It also updates the `src/plugins-pro` submodule to the latest commit.

**Configuration updates:**

* `configs/pro/profile.env`, `configs/offline/profile.env`: Changed `PUBLIC_SUPABASE_URL` from the default Supabase host to `https://auth.keeptrack.space`, ensuring authentication requests remain on the same registrable domain as the app. This prevents issues with certain secure web gateways that block random Supabase domains but allow `keeptrack.space` (#1406). [[1]](diffhunk://#diff-740885e411d720fc30f7fb3b864ff7fc092d486e8d5b4ba2a801107d97bfb87bL10-R14) [[2]](diffhunk://#diff-2c544a0c8a256872ebf70ebc9c3e75711266a490c6330a49907bfd625e35e4ddL4-R4)

**Submodule update:**

* [`src/plugins-pro`](diffhunk://#diff-269d6a3929be1f5cb462964314c836316739089246f9947976162a26b97882b3L1-R1): Updated the submodule to the latest commit `2aef3f72b723fe1995a8d38c1143dd45f561abe5`.