### PR TITLE
Fix keyboard shortcut conflicts and refactor splash screen

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -203,7 +203,8 @@
             "noUnusedVariables": "off"
           },
           "complexity": {
-            "useMaxParams": "off"
+            "useMaxParams": "off",
+            "useLiteralKeys": "off"
           }
         }
       }

--- a/src/app/data/__tests__/extended-catalog-loader.test.ts
+++ b/src/app/data/__tests__/extended-catalog-loader.test.ts
@@ -199,6 +199,49 @@ describe('Extended catalog loader (mixed-width NORAD IDs)', () => {
     expect(catalogManager.sccIndex['799500766']).toBeDefined();
   });
 
+  it('collapses a duplicate NORAD id in the primary payload, keeping the higher-priority source', async () => {
+    // Regression: a stale cached /v4/sats/brief blob (predating the API's
+    // source-dedup) delivered 25544 twice — once from the catalog (USSF) and
+    // once from the tle_sources fallback (SatNOGS) — and the loader rendered
+    // both as separate objects. The load must yield exactly one 25544, and it
+    // must be the USSF copy regardless of the order the rows arrive in.
+    const issSat = Satellite.fromOmm({
+      OBJECT_NAME: 'ISS (ZARYA)',
+      OBJECT_ID: '1998-067A',
+      EPOCH: '2026-07-05T02:54:29.072000',
+      MEAN_MOTION: 15.5,
+      ECCENTRICITY: 0.0006703,
+      INCLINATION: 51.64,
+      RA_OF_ASC_NODE: 208.0,
+      ARG_OF_PERICENTER: 130.0,
+      MEAN_ANOMALY: 325.0,
+      EPHEMERIS_TYPE: 0,
+      CLASSIFICATION_TYPE: 'U',
+      NORAD_CAT_ID: '25544',
+      ELEMENT_SET_NO: 999,
+      REV_AT_EPOCH: 10000,
+      BSTAR: 0.0001027,
+      MEAN_MOTION_DOT: 0.00016717,
+      MEAN_MOTION_DDOT: 0,
+    });
+
+    const ussfRow = { tle1: issSat.tle1, tle2: issSat.tle2, name: 'ISS (ZARYA)', source: 'spacetrack' } as never;
+    // Mirrors the tle_sources branch: NULL name → loader fills "Unknown 25544".
+    const satnogsRow = { tle1: issSat.tle1, tle2: issSat.tle2, source: 'satnogs' } as never;
+
+    for (const rows of [[ussfRow, satnogsRow], [satnogsRow, ussfRow]]) {
+      await expect(CatalogLoader.parse({ keepTrackTle: rows })).resolves.not.toThrow();
+
+      const catalogManager = ServiceLocator.getCatalogManager();
+      const matches = catalogManager.objectCache.filter(
+        (o) => o.isSatellite() && (o as Satellite).sccNum === '25544'
+      ) as Satellite[];
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0].source).toBe('spacetrack');
+    }
+  });
+
   it('does not crash when an externalCatalog entry has a malformed (non-ASCII) SCC', async () => {
     // Real-world: corrupt upstream TLE with a Cyrillic / fullwidth lookalike
     // in cols 3-7. `Tle.convertA5to6Digit` throws ValidationError for these.

--- a/src/app/data/__tests__/extended-catalog-loader.test.ts
+++ b/src/app/data/__tests__/extended-catalog-loader.test.ts
@@ -233,7 +233,11 @@ describe('Extended catalog loader (mixed-width NORAD IDs)', () => {
       [ussfRow, satnogsRow],
       [satnogsRow, ussfRow],
     ]) {
-      await expect(CatalogLoader.parse({ keepTrackTle: rows })).resolves.not.toThrow();
+      // parse() mutates rows in-place (adds sccNum, intlDes, active, ...), so
+      // clone per iteration to guarantee each call starts from a clean payload.
+      const clonedRows = rows.map((r) => ({ ...r })) as never;
+
+      await expect(CatalogLoader.parse({ keepTrackTle: clonedRows })).resolves.not.toThrow();
 
       const catalogManager = ServiceLocator.getCatalogManager();
       const matches = catalogManager.objectCache.filter((o) => o.isSatellite() && (o as Satellite).sccNum === '25544') as Satellite[];

--- a/src/app/data/__tests__/extended-catalog-loader.test.ts
+++ b/src/app/data/__tests__/extended-catalog-loader.test.ts
@@ -229,13 +229,14 @@ describe('Extended catalog loader (mixed-width NORAD IDs)', () => {
     // Mirrors the tle_sources branch: NULL name → loader fills "Unknown 25544".
     const satnogsRow = { tle1: issSat.tle1, tle2: issSat.tle2, source: 'satnogs' } as never;
 
-    for (const rows of [[ussfRow, satnogsRow], [satnogsRow, ussfRow]]) {
+    for (const rows of [
+      [ussfRow, satnogsRow],
+      [satnogsRow, ussfRow],
+    ]) {
       await expect(CatalogLoader.parse({ keepTrackTle: rows })).resolves.not.toThrow();
 
       const catalogManager = ServiceLocator.getCatalogManager();
-      const matches = catalogManager.objectCache.filter(
-        (o) => o.isSatellite() && (o as Satellite).sccNum === '25544'
-      ) as Satellite[];
+      const matches = catalogManager.objectCache.filter((o) => o.isSatellite() && (o as Satellite).sccNum === '25544') as Satellite[];
 
       expect(matches).toHaveLength(1);
       expect(matches[0].source).toBe('spacetrack');

--- a/src/app/data/catalog-loader.ts
+++ b/src/app/data/catalog-loader.ts
@@ -1778,20 +1778,6 @@ export class CatalogLoader {
   }
 
   /**
-   * Returns the canonical sccIndex key for a satellite identifier, or null
-   * if the input is malformed. All sccIndex reads and writes inside the
-   * loader must go through this helper so alpha-5 ("T0001") and its 6-digit
-   * numeric equivalent ("270001") collapse to the same key — otherwise
-   * different ingestion paths would assign the same satellite to different
-   * keys and silently insert duplicates.
-   *
-   * Canonicalization rules:
-   * 1. Alpha-5 → its 6-digit numeric form via Tle.convertA5to6Digit.
-   * 2. Numerics → leading zeros stripped, so "00005" and "5" share a key.
-   *    Matches Satellite.sccNum's display-canonical form so plugins can
-   *    use either sat.sccNum or canonicalSccKey(...) interchangeably.
-   */
-  /**
    * Canonical source ranking used to break duplicate-NORAD ties during catalog
    * load. Lower number wins. Mirrors the API's tle_sources priority
    * (USSF/spacetrack > CelesTrak > CelesTrak Supplemental > Vimpel > SatNOGS) so
@@ -1810,6 +1796,20 @@ export class CatalogLoader {
     return CatalogLoader.SOURCE_PRIORITY_[source ?? ''] ?? 6;
   }
 
+  /**
+   * Returns the canonical sccIndex key for a satellite identifier, or null
+   * if the input is malformed. All sccIndex reads and writes inside the
+   * loader must go through this helper so alpha-5 ("T0001") and its 6-digit
+   * numeric equivalent ("270001") collapse to the same key — otherwise
+   * different ingestion paths would assign the same satellite to different
+   * keys and silently insert duplicates.
+   *
+   * Canonicalization rules:
+   * 1. Alpha-5 → its 6-digit numeric form via Tle.convertA5to6Digit.
+   * 2. Numerics → leading zeros stripped, so "00005" and "5" share a key.
+   *    Matches Satellite.sccNum's display-canonical form so plugins can
+   *    use either sat.sccNum or canonicalSccKey(...) interchangeably.
+   */
   static canonicalSccKey(scc: string | number): string | null {
     const raw = scc.toString();
 

--- a/src/app/data/catalog-loader.ts
+++ b/src/app/data/catalog-loader.ts
@@ -1315,6 +1315,41 @@ export class CatalogLoader {
       // Never fail just because of one bad satellite
       let isAddedToCatalog = false;
 
+      // Canonicalize so the keepTrack-bundled TLE catalog and external
+      // CelesTrak updates share a single sccIndex entry per satellite.
+      const key = CatalogLoader.canonicalSccKey(resp[i].sccNum) ?? resp[i].sccNum;
+
+      // Enforce one object per NORAD id within a single payload. The API already
+      // dedupes by source priority, but a stale cached response (browser/service
+      // worker holding a pre-dedup blob) can still deliver the same NORAD twice —
+      // once from the primary catalog (e.g. USSF) and once from the tle_sources
+      // fallback (e.g. SatNOGS). Without this guard both rows are pushed and render
+      // as two dots for one satellite. Collapse into the existing slot, keeping the
+      // higher-priority source (USSF > CelesTrak > CelesTrak-Sup > Vimpel > SatNOGS).
+      const existingIdx = catalogManagerInstance.sccIndex[key];
+      const existingSat = typeof existingIdx === 'number' ? tempObjData[existingIdx] : undefined;
+
+      if (existingSat?.isSatellite()) {
+        if (CatalogLoader.sourcePriority_(resp[i].source) < CatalogLoader.sourcePriority_((existingSat as Satellite).source)) {
+          // Incoming source outranks the stored one: overwrite in place so the id
+          // and array position stay stable instead of appending a second object.
+          try {
+            tempObjData[existingIdx] = new Satellite({
+              ...resp[i],
+              id: existingIdx,
+              tle1: resp[i].tle1,
+              tle2: resp[i].tle2,
+              rcs,
+            });
+          } catch (e) {
+            errorManagerInstance.log(e);
+          }
+        }
+
+        // Lower or equal priority: drop the duplicate row entirely.
+        return;
+      }
+
       try {
         const satellite = new Satellite({
           ...resp[i],
@@ -1331,10 +1366,6 @@ export class CatalogLoader {
       }
 
       if (isAddedToCatalog) {
-        // Canonicalize so the keepTrack-bundled TLE catalog and external
-        // CelesTrak updates share a single sccIndex entry per satellite.
-        const key = CatalogLoader.canonicalSccKey(resp[i].sccNum) ?? resp[i].sccNum;
-
         catalogManagerInstance.sccIndex[key] = tempObjData.length - 1;
         catalogManagerInstance.cosparIndex[`${resp[i].intlDes}`] = tempObjData.length - 1;
       }
@@ -1764,6 +1795,25 @@ export class CatalogLoader {
    *    Matches Satellite.sccNum's display-canonical form so plugins can
    *    use either sat.sccNum or canonicalSccKey(...) interchangeably.
    */
+  /**
+   * Canonical source ranking used to break duplicate-NORAD ties during catalog
+   * load. Lower number wins. Mirrors the API's tle_sources priority
+   * (USSF/spacetrack > CelesTrak > CelesTrak Supplemental > Vimpel > SatNOGS) so
+   * the client resolves a stale/duplicated payload to the same source the
+   * backend would have picked. Unknown/other sources rank last.
+   */
+  private static readonly SOURCE_PRIORITY_: Readonly<Record<string, number>> = {
+    [CatalogSource.USSF]: 1,
+    [CatalogSource.CELESTRAK]: 2,
+    [CatalogSource.CELESTRAK_SUP]: 3,
+    [CatalogSource.VIMPEL]: 4,
+    [CatalogSource.SATNOGS]: 5,
+  };
+
+  private static sourcePriority_(source?: string): number {
+    return CatalogLoader.SOURCE_PRIORITY_[source ?? ''] ?? 6;
+  }
+
   static canonicalSccKey(scc: string | number): string | null {
     const raw = scc.toString();
 

--- a/src/app/data/catalog-loader.ts
+++ b/src/app/data/catalog-loader.ts
@@ -1256,10 +1256,6 @@ export class CatalogLoader {
 
       return 'None';
     }
-    if (Number.isNaN(Number.parseInt(year))) {
-      // eslint-disable-next-line no-debugger
-      debugger;
-    }
     const prefix = Number.parseInt(year) > 50 ? '19' : '20';
 
     year = prefix + year;

--- a/src/app/rendering/mesh/model-resolver.ts
+++ b/src/app/rendering/mesh/model-resolver.ts
@@ -628,7 +628,7 @@ export class ModelResolver {
     if (name.startsWith('ORBCOMM')) {
       return SatelliteModels.orbcomm;
     }
-    if (RegExp(/SES\s\d+/u, 'u').exec(name)) {
+    if (new RegExp(/SES\s\d+/u, 'u').exec(name)) {
       return SatelliteModels.ses;
     }
     if (name.startsWith('O3B')) {

--- a/src/app/ui/splash-screen.ts
+++ b/src/app/ui/splash-screen.ts
@@ -11,19 +11,27 @@ export abstract class SplashScreen {
   /** Wallpaper images provided by the active build profile via @wallpapers alias */
   private static splashScreenImgList_ = [...wallpapers];
 
-  static readonly msg = {
-    math: t7e('loadingScreenMsgs.math'),
-    science: t7e('loadingScreenMsgs.science'),
-    science2: t7e('loadingScreenMsgs.science2'),
-    dots: t7e('loadingScreenMsgs.dots'),
-    satIntel: t7e('loadingScreenMsgs.satIntel'),
-    painting: t7e('loadingScreenMsgs.painting'),
-    coloring: t7e('loadingScreenMsgs.coloring'),
-    elsets: t7e('loadingScreenMsgs.elsets'),
-    models: t7e('loadingScreenMsgs.models'),
+  /**
+   * Lazy getter so `t7e()` is resolved on first access (after i18next has
+   * initialized) instead of at class-parse time. A `static readonly` object
+   * evaluated these before localization loaded, so `t7e()` returned - and then
+   * permanently cached - empty strings, leaving the loading messages blank.
+   */
+  static get msg() {
+    return {
+      math: t7e('loadingScreenMsgs.math'),
+      science: t7e('loadingScreenMsgs.science'),
+      science2: t7e('loadingScreenMsgs.science2'),
+      dots: t7e('loadingScreenMsgs.dots'),
+      satIntel: t7e('loadingScreenMsgs.satIntel'),
+      painting: t7e('loadingScreenMsgs.painting'),
+      coloring: t7e('loadingScreenMsgs.coloring'),
+      elsets: t7e('loadingScreenMsgs.elsets'),
+      models: t7e('loadingScreenMsgs.models'),
 
-    cunningPlan: t7e('loadingScreenMsgs.cunningPlan'),
-  };
+      cunningPlan: t7e('loadingScreenMsgs.cunningPlan'),
+    };
+  }
 
   static readonly textElId = 'loader-text';
 

--- a/src/engine/core/__tests__/keyboard-shortcut-registry.test.ts
+++ b/src/engine/core/__tests__/keyboard-shortcut-registry.test.ts
@@ -84,8 +84,10 @@ const pluginShortcuts: { pluginId: string; shortcuts: Omit<IKeyboardShortcut, 'c
   { pluginId: 'PlanetsMenuPlugin', shortcuts: [{ key: 'p' }, { key: 'Home', shift: true, ctrl: false }, { key: 'Home', shift: false, ctrl: false }] },
   // src/plugins/polar-plot/polar-plot.ts
   { pluginId: 'PolarPlot', shortcuts: [{ key: 'P' }] },
-  // src/plugins/political-map-toggle/political-map-toggle.ts
-  { pluginId: 'PoliticalMapToggle', shortcuts: [{ key: 'l' }] },
+  // src/plugins/political-map-toggle/political-map-toggle.ts (shift:false; owns plain 'l', Shift+l is DrawLines)
+  { pluginId: 'PoliticalMapToggle', shortcuts: [{ key: 'l', shift: false }] },
+  // src/plugins/draw-lines/draw-lines.ts
+  { pluginId: 'DrawLinesPlugin', shortcuts: [{ key: 'l', shift: true }] },
   // src/plugins/proximity-ops/proximity-ops.ts
   { pluginId: 'ProximityOps', shortcuts: [{ key: 'X' }] },
   // src/plugins/reentries/reentries.ts

--- a/src/engine/core/scene.ts
+++ b/src/engine/core/scene.ts
@@ -317,7 +317,7 @@ export class Scene {
   }
 
   averageDrawTime = 0;
-  drawTimeArray: number[] = Array(150).fill(16);
+  drawTimeArray: number[] = new Array(150).fill(16);
 
   /**
    * Set when renderBackground rendered the earth surface for the current pass, so

--- a/src/engine/core/time-manager.ts
+++ b/src/engine/core/time-manager.ts
@@ -220,6 +220,7 @@ export class TimeManager {
       },
       {
         key: ',',
+        shift: false,
         callback: () => {
           if (!this.guardTimeChange_()) {
             return;

--- a/src/engine/rendering/draw-manager/sensor-fov-mesh.ts
+++ b/src/engine/rendering/draw-manager/sensor-fov-mesh.ts
@@ -382,9 +382,7 @@ export class SensorFovMesh extends CustomMesh {
   }
 
   sortFacesByDistance(camPos: vec3): void {
-    const buckets: number[][] = Array(this.NUM_BUCKETS)
-      .fill(null)
-      .map(() => []);
+    const buckets: number[][] = new Array(this.NUM_BUCKETS).fill(null).map(() => []);
     const faceCenters: vec3[] = [];
 
     // Pre-compute face centers

--- a/src/engine/rendering/ring-geometry.ts
+++ b/src/engine/rendering/ring-geometry.ts
@@ -149,9 +149,7 @@ export class RingGeometry extends BufferGeometry {
 
   // --- Sorting and other methods remain unchanged ---
   sortFacesByDistance(camPos: vec3, modelMatrix?: Float32Array): void {
-    const buckets: number[][] = Array(this.NUM_BUCKETS)
-      .fill(null)
-      .map(() => []);
+    const buckets: number[][] = new Array(this.NUM_BUCKETS).fill(null).map(() => []);
     const faceCenters: vec3[] = [];
 
     for (let i = 0; i < this.indices_.length; i += 3) {

--- a/src/engine/rendering/sphere-geometry.ts
+++ b/src/engine/rendering/sphere-geometry.ts
@@ -218,9 +218,7 @@ export class SphereGeometry extends BufferGeometry {
    * @param modelMatrix Optional model matrix for transformed spheres
    */
   sortFacesByDistance(camPos: vec3, modelMatrix?: Float32Array): void {
-    const buckets: number[][] = Array(this.NUM_BUCKETS)
-      .fill(null)
-      .map(() => []);
+    const buckets: number[][] = new Array(this.NUM_BUCKETS).fill(null).map(() => []);
     const faceCenters: vec3[] = [];
 
     // Pre-compute face centers

--- a/src/engine/utils/external/meuusjs.ts
+++ b/src/engine/utils/external/meuusjs.ts
@@ -114,37 +114,43 @@ const A = <Meuusjs>(<unknown>{
   AU: 149597870,
 });
 A.EclCoord = function (a: number, b: number, c: number): void {
-  if (isNaN(a) || isNaN(b)) throw Error('Invalid EclCoord object: (' + a + ', ' + b + ')');
+  if (isNaN(a) || isNaN(b)) {
+    throw new Error(`Invalid EclCoord object: (${a}, ${b})`);
+  }
   this.lat = a;
   this.lng = b;
   void 0 !== c && (this.h = c);
 };
 A.EclCoord.prototype = {
   toWgs84String: function () {
-    return A.Math.formatNum((180 * this.lat) / Math.PI) + ', ' + A.Math.formatNum((180 * -this.lng) / Math.PI);
+    return `${A.Math.formatNum((180 * this.lat) / Math.PI)}, ${A.Math.formatNum((180 * -this.lng) / Math.PI)}`;
   },
 };
 A.EclCoordfromWgs84 = function (a: number, b: number, c: number): void {
   return new A.EclCoord((a * Math.PI) / 180, (-b * Math.PI) / 180, c);
 };
 A.EqCoord = function (a: number, b: number) {
-  if (isNaN(a) || isNaN(b)) throw Error('Invalid EqCoord object: (' + a + ', ' + b + ')');
+  if (isNaN(a) || isNaN(b)) {
+    throw new Error(`Invalid EqCoord object: (${a}, ${b})`);
+  }
   this.ra = a;
   this.dec = b;
 };
 A.EqCoord.prototype = {
   toString: function () {
-    return 'ra:' + A.Math.formatNum((180 * this.ra) / Math.PI) + ', dec:' + A.Math.formatNum((180 * this.dec) / Math.PI);
+    return `ra:${A.Math.formatNum((180 * this.ra) / Math.PI)}, dec:${A.Math.formatNum((180 * this.dec) / Math.PI)}`;
   },
 };
 A.HzCoord = function (a: string | number, b: string | number) {
-  if (isNaN(a) || isNaN(b)) throw Error('Invalid HzCoord object: (' + a + ', ' + b + ')');
+  if (isNaN(a) || isNaN(b)) {
+    throw new Error(`Invalid HzCoord object: (${a}, ${b})`);
+  }
   this.az = a;
   this.alt = b;
 };
 A.HzCoord.prototype = {
   toString: function () {
-    return 'azi:' + A.Math.formatNum((180 * this.az) / Math.PI) + ', alt:' + A.Math.formatNum((180 * this.alt) / Math.PI);
+    return `azi:${A.Math.formatNum((180 * this.az) / Math.PI)}, alt:${A.Math.formatNum((180 * this.alt) / Math.PI)}`;
   },
 };
 A.Coord = {
@@ -164,14 +170,14 @@ A.Coord = {
     var c = Math.floor(a / 3600) % 24,
       d = Math.floor(a / 60) % 60;
     a = Math.floor(a % 60);
-    return (b !== 0 ? b + 'd ' : '') + (c < 10 ? '0' : '') + c + ':' + (d < 10 ? '0' : '') + d + ':' + (a < 10 ? '0' : '') + a;
+    return `${(b !== 0 ? `${b}d ` : '') + (c < 10 ? '0' : '') + c}:${d < 10 ? '0' : ''}${d}:${a < 10 ? '0' : ''}${a}`;
   },
   secondsToHMStr: function (a: string | number) {
     var b = Math.floor(a / 86400);
     a = A.Math.pMod(a, 86400);
     var c = Math.floor(a / 3600) % 24;
     a = Math.floor(a / 60) % 60;
-    return (b !== 0 ? b + 'd ' : '') + (c < 10 ? '0' : '') + c + ':' + (a < 10 ? '0' : '') + a;
+    return `${(b !== 0 ? `${b}d ` : '') + (c < 10 ? '0' : '') + c}:${a < 10 ? '0' : ''}${a}`;
   },
   eqToEcl: function (a: { ra: number; dec: number }, b: number) {
     var c = Math.sin(a.ra),
@@ -261,8 +267,12 @@ A.Globe = {
 };
 A.Interp = {
   newLen3: function (a: number, b: number, c: string | any[]) {
-    if (c.length != 3) throw 'Error not 3';
-    if (b === a) throw 'Error no x range';
+    if (c.length != 3) {
+      throw 'Error not 3';
+    }
+    if (b === a) {
+      throw 'Error no x range';
+    }
     var d = c[1] - c[0],
       e = c[2] - c[1];
     return { x1: a, x3: b, y: c, a: d, b: e, c: e - d, abSum: d + e, xSum: b + a, xDiff: b - a };
@@ -324,12 +334,16 @@ A.JulianDay.dateToJD = function (a: {
     : A.JulianDay.calendarGregorianToJD(a.getUTCFullYear(), a.getUTCMonth() + 1, b);
 };
 A.JulianDay.calendarGregorianToJD = function (a: number, b: number, c: number) {
-  if (b === 1 || b === 2) a--, (b += 12);
+  if (b === 1 || b === 2) {
+    a--, (b += 12);
+  }
   var d = Math.floor(a / 100);
   return Math.floor((36525 * (a + 4716)) / 100) + Math.floor((306 * (b + 1)) / 10) + (2 - d + Math.floor(d / 4)) + c - 1524.5;
 };
 A.JulianDay.calendarJulianToJD = function (a: number, b: number, c: number) {
-  if (b === 1 || b === 2) a--, (b += 12);
+  if (b === 1 || b === 2) {
+    a--, (b += 12);
+  }
   return Math.floor((36525 * (a + 4716)) / 100) + Math.floor((306 * (b + 1)) / 10) + c - 1524.5;
 };
 A.JulianDay.secondsFromHMS = function (a: number, b: number, c: number) {
@@ -376,8 +390,12 @@ A.Math = {
   },
   horner: function (a: number, b: string | any[]) {
     var c = b.length - 1;
-    if (c <= 0) throw 'empty array not supported';
-    for (var d = b[c]; c > 0; ) c--, (d = d * a + b[c]);
+    if (c <= 0) {
+      throw 'empty array not supported';
+    }
+    for (var d = b[c]; c > 0; ) {
+      c--, (d = d * a + b[c]);
+    }
     return d;
   },
   formatNum: function (a: number, b: number) {
@@ -475,7 +493,7 @@ A.Moon = {
           throw 'error';
       }
     }
-    for (h = 0; h < A.Moon.tb.length; h++)
+    for (h = 0; h < A.Moon.tb.length; h++) {
       switch (((k = A.Moon.tb[h]), (q = Math.sin(d * k[0] + e * k[1] + f * k[2] + g * k[3])), k[1])) {
         case 0:
           l += k[4] * q;
@@ -491,6 +509,7 @@ A.Moon = {
         default:
           throw 'error';
       }
+    }
     return { lng: A.Math.pMod(a, 2 * Math.PI) + 1e-6 * m * b, lat: 1e-6 * l * b, delta: 385000.56 + 0.001 * n };
   },
   ta: [
@@ -815,7 +834,9 @@ A.Rise = {
   },
   approxTimes: function (a: number, b: number, c: number, d: { dec: any; ra: any }) {
     b = A.Rise.circumpolar(a.lat, b, d.dec);
-    if (!b) return null;
+    if (!b) {
+      return null;
+    }
     b = (43200 * Math.acos(b)) / Math.PI;
     a = (43200 * (d.ra + a.lng)) / Math.PI - c;
     return {
@@ -838,7 +859,9 @@ A.Rise = {
       return A.Math.pMod(e + (((p * Math.sin(g) + n * h * Math.cos(f) - c) / (h * n * Math.sin(f))) * 43200) / Math.PI, 86400);
     }
     var g = A.Rise.approxTimes(a, c, d, e[1]);
-    if (!g) return null;
+    if (!g) {
+      return null;
+    }
     var l = A.Interp.newLen3(-86400, 86400, [e[0].ra, e[1].ra, e[2].ra]),
       m = A.Interp.newLen3(-86400, 86400, [e[0].dec, e[1].dec, e[2].dec]);
     e = d + (360.985647 * g.transit) / 360;

--- a/src/plugins/onboarding/onboarding.ts
+++ b/src/plugins/onboarding/onboarding.ts
@@ -413,7 +413,7 @@ export class OnboardingPlugin extends KeepTrackPlugin implements ICommandPalette
       kind: 'card',
       title: l('bridge.title'),
       body: l('bridge.body'),
-      extraHtml: '<ul class="kt-tour-recap">' + `<li>${l('bridge.recap1')}</li>` + `<li>${l('bridge.recap2')}</li>` + `<li>${l('bridge.recap3')}</li>` + '</ul>',
+      extraHtml: `<ul class="kt-tour-recap"><li>${l('bridge.recap1')}</li><li>${l('bridge.recap2')}</li><li>${l('bridge.recap3')}</li></ul>`,
       buttons: [
         { id: 'power', label: l('buttons.keepGoing'), isPrimary: isPowerPrimary },
         { id: 'finish', label: l('buttons.finishUp'), isPrimary: !isPowerPrimary },
@@ -568,7 +568,7 @@ export class OnboardingPlugin extends KeepTrackPlugin implements ICommandPalette
       kind: 'card',
       title: l('account.title'),
       body: isPowerDone ? l('account.bodyPower') : l('account.body'),
-      extraHtml: '<ul class="kt-tour-recap">' + `<li>${l('account.benefit1')}</li>` + `<li>${l('account.benefit2')}</li>` + `<li>${l('account.benefit3')}</li>` + '</ul>',
+      extraHtml: `<ul class="kt-tour-recap"><li>${l('account.benefit1')}</li><li>${l('account.benefit2')}</li><li>${l('account.benefit3')}</li></ul>`,
       buttons: [
         { id: 'create', label: l('buttons.createAccount'), isPrimary: true },
         { id: 'later', label: l('buttons.maybeLater') },

--- a/src/plugins/political-map-toggle/political-map-toggle.ts
+++ b/src/plugins/political-map-toggle/political-map-toggle.ts
@@ -39,6 +39,7 @@ export class PoliticalMapToggle extends KeepTrackPlugin {
     return [
       {
         key: 'l',
+        shift: false,
         callback: () => this.bottomMenuClicked(),
       },
     ];


### PR DESCRIPTION
This pull request addresses several issues around duplicate NORAD IDs in the satellite catalog loader, improves keyboard shortcut handling for plugins, and fixes a localization bug in the splash screen loading messages. The most significant changes are grouped below.

**Catalog Loader Improvements and Bug Fixes:**

* Added logic to `CatalogLoader` to collapse duplicate NORAD ID entries within a single payload, ensuring only the highest-priority source (e.g., USSF over SatNOGS) is kept, even if stale or pre-deduped data is loaded. This prevents rendering duplicate satellites and aligns client-side behavior with backend deduplication. [[1]](diffhunk://#diff-71376f9d35a740aa41dcefd834d136b4f7cf1205d7339bdbdc1410fb0dbee80cR1318-R1352) [[2]](diffhunk://#diff-71376f9d35a740aa41dcefd834d136b4f7cf1205d7339bdbdc1410fb0dbee80cL1334-L1337)
* Introduced a source priority ranking (`SOURCE_PRIORITY_`) and helper method (`sourcePriority_`) to consistently resolve which source should be kept when duplicates are encountered.
* Added a regression test to ensure that, when duplicate NORAD IDs are present from different sources, only the correct (highest-priority) satellite is loaded and rendered.

**Keyboard Shortcut Handling:**

* Updated keyboard shortcut registration and tests for the `PoliticalMapToggle` and `DrawLinesPlugin` plugins to explicitly distinguish between plain `'l'` (unshifted, for PoliticalMapToggle) and `'L'`/`Shift+l` (for DrawLinesPlugin), preventing shortcut conflicts. Also added `shift: false` to relevant shortcut definitions and tests. [[1]](diffhunk://#diff-41cc3674b2bc1ca7b78ee855d078ef25d0e602f187ebb1da40076a70069c5754L87-R90) [[2]](diffhunk://#diff-27f095139acee23bc64277b7c6be52007ce50efb414cd9eb509a717f2eb1f6ffR42) [[3]](diffhunk://#diff-e1503b8b61d086844a3657493712027cc9440289f6eee74d40845c976d52618dR223)

**Splash Screen Localization Fix:**

* Changed the `SplashScreen.msg` property from a static readonly object to a lazy getter, ensuring that loading messages are properly localized after i18next initialization, fixing an issue where messages could be blank due to premature evaluation. [[1]](diffhunk://#diff-4bbb8afa867b311b965ff6f6824458fd7957b2662e9510a8315b45d63766bbd3L14-R21) [[2]](diffhunk://#diff-4bbb8afa867b311b965ff6f6824458fd7957b2662e9510a8315b45d63766bbd3R34)