### PR TITLE
Adjust ad placeholder positioning and cap fork concurrency

### DIFF
--- a/configs/celestrak/loading-screen.css
+++ b/configs/celestrak/loading-screen.css
@@ -18,7 +18,3 @@
   /* Deep blue for accents */
   --color-primary-dark: #023456 !important;
 }
-
-#loading-hint {
-  bottom: 15%;
-}

--- a/public/css/loading-screen.common.css
+++ b/public/css/loading-screen.common.css
@@ -206,10 +206,34 @@
   padding-left: 5%;
   padding-top: 5px;
   padding-bottom: 5px;
-  bottom: max(170px, 20%);
+  /* Top half of the screen - the bottom band is reserved for the responsive ad */
+  top: max(70px, 10%);
   text-shadow:
     0px 0px 8px rgb(0 0 0),
     0px 0px 8px rgb(0 0 0);
+}
+
+/*
+ * Reserved band for the responsive splash ad (shown to guests by the pro
+ * AdsController). Height must NEVER reach the start button: the logo/button
+ * stack is vertically centered and overflows below 50vh by up to ~180px on
+ * wide viewports, so the tall (250px) reservation only applies when
+ * 50vh - 260px allows it. Phones stack more compactly, hence the wider
+ * allowance under 800px so they can still fit a 300x250.
+ */
+#adsense-placeholder {
+  display: none;
+  position: absolute;
+  bottom: 50px;
+  width: min(970px, calc(100vw - 24px));
+  height: clamp(90px, 50vh - 260px, 250px);
+  margin: 16px 0;
+}
+
+@media (max-width: 800px) {
+  #adsense-placeholder {
+    height: clamp(90px, 50vh - 170px, 250px);
+  }
 }
 
 #mobile-start-button {

--- a/src/app/ui/splash-screen.ts
+++ b/src/app/ui/splash-screen.ts
@@ -54,9 +54,7 @@ export abstract class SplashScreen {
           <div style="height: 50px; min-height: 50px; max-height: 50px; margin-top: 1rem; display: flex; align-items: center;">
             <span id="loader-text" style="width: 100%;">${t7e('loadingScreen.downloadingScience' as TranslationKey)}</span>
           </div>
-          <div id="adsense-placeholder"
-            style="width:970px;height:90px; margin:16px 0; display: none; position: absolute; bottom: 50px">
-          </div>
+          <div id="adsense-placeholder"></div>
           <div style="height:36px; min-height:36px; max-height:36px; position: relative;">
             <button
             id="start-app-btn"

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { readFileSync } from 'fs';
+import os from 'node:os';
 import path from 'path';
 import { defineConfig } from 'vitest/config';
 
@@ -43,6 +44,14 @@ export default defineConfig({
     },
   ],
   test: {
+    /*
+     * Cap fork concurrency. The default (one fork per logical core - 32 on the
+     * dev box) makes the initial worker burst exceed what Windows will commit,
+     * and forks die semi-randomly with "Zone Allocation failed - process out
+     * of memory" at a few hundred MB of JS heap, failing the pre-push run.
+     * 12 forks bounds peak memory; CI runners (2-4 cores) are unaffected.
+     */
+    maxWorkers: Math.min(12, Math.max(1, os.availableParallelism() - 1)),
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./test/polyfills.js', './test/vitest-setup.ts'],


### PR DESCRIPTION
This pull request updates the loading screen layout and ad placeholder logic, improves test stability by capping test runner concurrency, and updates a plugin submodule. The main changes are grouped below:

**Loading Screen Layout and Ad Placeholder Updates:**

* Moved the loading hint positioning logic from `configs/celestrak/loading-screen.css` to `public/css/loading-screen.common.css` and removed the redundant CSS rule for `#loading-hint` (`[configs/celestrak/loading-screen.cssL21-L24](diffhunk://#diff-24ba930e43535a44d239b6968db1ff2133d4e2763c6d512a6f714651a8ff3900L21-L24)`).
* Redesigned the ad placeholder: removed inline styles from the `#adsense-placeholder` div in the splash screen template and centralized its styling in `loading-screen.common.css`. The placeholder now uses responsive CSS to reserve space for ads without interfering with the start button, adapting its height for different viewport sizes (`[[1]](diffhunk://#diff-4bbb8afa867b311b965ff6f6824458fd7957b2662e9510a8315b45d63766bbd3L57-R57)`, `[[2]](diffhunk://#diff-2cd3dec36bf0a637b2c9b0fa6ed06fe747a4bd49f98318f43eb8ab3415525e52L209-R238)`).

**Testing Improvements:**

* Limited Vitest's parallel test worker count to a maximum of 12 (or one less than the number of available logical cores) to prevent out-of-memory errors during local development, especially on high-core-count Windows machines (`[[1]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R47-R54)`, `[[2]](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92R3)`).

**Dependency Updates:**

* Updated the `src/plugins-pro` submodule to the latest commit (`[src/plugins-proL1-R1](diffhunk://#diff-269d6a3929be1f5cb462964314c836316739089246f9947976162a26b97882b3L1-R1)`).